### PR TITLE
v1.7.1: if device can't be contacted, return off values instead of 'Not Responding'

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ Via config.json:
 
 By default, if you disconnect a humidifier from WiFi, it will begin showing as "Not Responding" in HomeKit. Restarting
 Homebridge will remove the cached device from HomeKit. Once you've re-connected the humidifier, restart Homebridge again
-for it to display back in HomeKit. If you prefer the disconnected device to be visible in HomeKit at all times,
+for it to display back in HomeKit. 
+
+If you prefer the disconnected device to be visible in HomeKit at all times,
 set `showOffWhenDisconnected` to `true` in the config. The humidifiers will remain in HomeKit in an Off state.
 **Note: This will result in benign warnings in the Homebridge logs that the device returned undefined values.**
 

--- a/README.md
+++ b/README.md
@@ -94,13 +94,15 @@ Via config.json:
       "email": "email",
       "password": "password",
       "platform": "LevoitHumidifiers",
-      "showOffWhenDisconnected": false,
       "accessories": {
         "display": false,
         "sleep_mode": false,
         "cool_mist": false,
         "warm_mist": false,
         "night_light": false
+      },
+      "options": {
+        "showOffWhenDisconnected": false
       }
     }
   ]
@@ -127,7 +129,6 @@ In the config file, add `enableDebugMode: true`
       "email": "email",
       "password": "password",
       "platform": "LevoitHumidifiers",
-      "showOffWhenDisconnected": false,
       "enableDebugMode": true
     }
   ]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Homebridge Levoit Humidifiers
+
 [![verified-by-homebridge](https://badgen.net/badge/homebridge/verified/purple)](https://github.com/homebridge/homebridge/wiki/Verified-Plugins)
 
 This is a Homebridge plugin to control Levoit Humidifiers via the VeSync Platform.
@@ -10,33 +11,37 @@ This is a Homebridge plugin to control Levoit Humidifiers via the VeSync Platfor
 | Classic 200S         | ✅         | ✅         | ❌          | ❌           | ✅              | ✅               | ❌         |
 | Dual 200S            | ✅         | ✅         | ❌          | ❌           | ✅              | ✅               | ❌         |
 
-This plugin was forked from [RaresAil's Levoit Air Purifiers repo](https://github.com/RaresAil/homebridge-levoit-air-purifier) and adds logic for the Levoit Humidifers.
+This plugin was forked
+from [RaresAil's Levoit Air Purifiers repo](https://github.com/RaresAil/homebridge-levoit-air-purifier) and adds logic
+for the Levoit Humidifers.
 
 ### Features
 
-1. Humidifier / Auto Mode 
+1. Humidifier / Auto Mode
     - Sets humidifier to Auto / Humidity and sets the Target Humidity to the desired level.
     - Can also change Target Humidity in Sleep Mode, except on LV600s.
-      - For LV600s, the Humidifier slider will be set to 0% when Sleep Mode is on.
+        - For LV600s, the Humidifier slider will be set to 0% when Sleep Mode is on.
     - For LV600s, the Auto humidity range is 40-80%. All other models are 30-80%.
-      - Selecting values outside the Auto range will set the Target Humidity to the lowest or highest number in the range.
+        - Selecting values outside the Auto range will set the Target Humidity to the lowest or highest number in the
+          range.
 
 2. Cool Mist Level
     - Sets humidifier to Manual mode (except on LV600s) and sets the Cool Mist Level to the desired level.
-      - Note: LV600s supports changing mist levels while in Auto mode.
+        - Note: LV600s supports changing mist levels while in Auto mode.
     - When set to Level 0, turns the device off.
     - Levels 1-9 on Classic300s, Classic200s, and LV600S
     - Levels 1-2 on Dual200s
 
 3. Warm Mist Level
-   - Sets Warm Mist Level to the desired level.
-   - Levels 0-3 on LV600s only.
+    - Sets Warm Mist Level to the desired level.
+    - Levels 0-3 on LV600s only.
 
 4. Sleep Mode
     - This switches the device between Sleep Mode (On) and Auto Mode (Off)
     - Sleep Mode Target Humidity is controlled by the Target Humidity slider, except on LV600s.
     - On LV600s, Sleep Mode Target Humidity is set by VeSync at 50–60% and cannot be changed.
-    - The LV600s turns off Warm Mist by default to keep the humidifier quiet. It can be turned back on with the Warm Mist slider.
+    - The LV600s turns off Warm Mist by default to keep the humidifier quiet. It can be turned back on with the Warm
+      Mist slider.
 
 5. Night Light
     - Supported on Classic300s
@@ -72,14 +77,19 @@ credentials are only stored in the Homebridge config and not sent to any server 
 You can also do this directly via the Homebridge config by adding your credentials to the config file under platforms.
 Replace the values of `username` and `password` with your credentials.
 
-You can turn off optional controls via the `accessories` section of the config or through the plugin UI settings.
-The Humidifier (Auto mode) slider and the Humidity sensor cannot be turned off and will always be exposed.
+Set `showOffWhenDisconnected` to `true` if you'd like the humidifiers to display as `Off` instead of `Not Responding`
+when disconnected from WiFi. This is helpful if you only use your humidifiers during certain parts of the year. Warning:
+This setting may result in "Slow to Respond" warnings in the Homebridge logs.
+
+You can turn off optional controls via the `accessories` section of the config or through the plugin UI settings. The
+Humidifier (Auto mode) slider and the Humidity sensor cannot be turned off and will always be exposed.
 
 Via UI:
 
 <img src="images/homebridgeUI.png" width="500"/>
 
 Via config.json:
+
 ```json
 {
   "platforms": [
@@ -88,12 +98,13 @@ Via config.json:
       "email": "email",
       "password": "password",
       "platform": "LevoitHumidifiers",
+      "showOffWhenDisconnected": false,
       "accessories": {
-         "display": false, 
-         "sleep_mode": false, 
-         "cool_mist": false, 
-         "warm_mist": false,
-         "night_light": false
+        "display": false,
+        "sleep_mode": false,
+        "cool_mist": false,
+        "warm_mist": false,
+        "night_light": false
       }
     }
   ]
@@ -112,6 +123,7 @@ In the config file, add `enableDebugMode: true`
       "email": "email",
       "password": "password",
       "platform": "LevoitHumidifiers",
+      "showOffWhenDisconnected": false,
       "enableDebugMode": true
     }
   ]

--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ credentials are only stored in the Homebridge config and not sent to any server 
 You can also do this directly via the Homebridge config by adding your credentials to the config file under platforms.
 Replace the values of `username` and `password` with your credentials.
 
-Set `showOffWhenDisconnected` to `true` if you'd like the humidifiers to display as `Off` instead of `Not Responding`
-when disconnected from WiFi. This is helpful if you only use your humidifiers during certain parts of the year. Warning:
-This setting may result in "Slow to Respond" warnings in the Homebridge logs.
-
 You can turn off optional controls via the `accessories` section of the config or through the plugin UI settings. The
 Humidifier (Auto mode) slider and the Humidity sensor cannot be turned off and will always be exposed.
 
@@ -110,6 +106,14 @@ Via config.json:
   ]
 }
 ```
+
+### Note to Seasonal Humidifier Users:
+By default, if you disconnect a humidifier from WiFi, it will begin showing as "Not Responding" in HomeKit. Restarting
+Homebridge will remove the cached device from HomeKit. Once you've re-connected the humidifier, restart Homebridge again
+for it to display back in HomeKit.
+If you prefer the disconnected device to be visible in HomeKit at all times, set `showOffWhenDisconnected` to `true` in
+the config. The humidifiers will remain in HomeKit in an Off state.
+**Note: This will result in benign warnings in the Homebridge logs that the device returned undefined values.**
 
 ### Enabling Debug Mode
 

--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ Via config.json:
 ```
 
 ### Note to Seasonal Humidifier Users:
+
 By default, if you disconnect a humidifier from WiFi, it will begin showing as "Not Responding" in HomeKit. Restarting
 Homebridge will remove the cached device from HomeKit. Once you've re-connected the humidifier, restart Homebridge again
-for it to display back in HomeKit.
-If you prefer the disconnected device to be visible in HomeKit at all times, set `showOffWhenDisconnected` to `true` in
-the config. The humidifiers will remain in HomeKit in an Off state.
+for it to display back in HomeKit. If you prefer the disconnected device to be visible in HomeKit at all times,
+set `showOffWhenDisconnected` to `true` in the config. The humidifiers will remain in HomeKit in an Off state.
 **Note: This will result in benign warnings in the Homebridge logs that the device returned undefined values.**
 
 ### Enabling Debug Mode

--- a/config.schema.json
+++ b/config.schema.json
@@ -23,12 +23,6 @@
         "required": true,
         "description": "VeSync's account password"
       },
-      "showOffWhenDisconnected": {
-        "title": "Show Off When Disconnected",
-        "type": "boolean",
-        "default": false,
-        "description": "When disconnected from WiFi, HomeKit will display devices as Off instead of Not Responding"
-      },
       "accessories": {
         "type": "object",
         "properties": {
@@ -61,6 +55,17 @@
             "type": "boolean",
             "default": true,
             "description": "Enable brightness slider / switch for the Night Light"
+          }
+        }
+      },
+      "options": {
+        "type": "object",
+        "properties": {
+          "showOffWhenDisconnected": {
+            "title": "Show Off When Disconnected",
+            "type": "boolean",
+            "default": false,
+            "description": "When set to true, HomeKit will display unresponsive humidifiers as Off instead of Not Responding. Read the \"Note to Seasonal Humidifier Users\" in the README for more info."
           }
         }
       }

--- a/config.schema.json
+++ b/config.schema.json
@@ -23,11 +23,11 @@
         "required": true,
         "description": "VeSync's account password"
       },
-      "password": {
-        "title": "Password",
-        "type": "string",
-        "required": true,
-        "description": "VeSync's account password"
+      "showOffWhenDisconnected": {
+        "title": "Show Off When Disconnected",
+        "type": "boolean",
+        "default": false,
+        "description": "When disconnected from WiFi, HomeKit will display devices as Off instead of Not Responding"
       },
       "accessories": {
         "type": "object",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.7.0",
+  "version": "1.7.1-beta1",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.7.1-beta3",
+  "version": "1.7.1-beta4",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.7.1-beta1",
+  "version": "1.7.1-beta3",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.7.1-beta5",
+  "version": "1.7.1",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.7.1-beta4",
+  "version": "1.7.1-beta5",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"

--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -1,5 +1,5 @@
 import axios, {AxiosInstance} from 'axios';
-import {Logger} from 'homebridge';
+import {Logger, PlatformConfig} from 'homebridge';
 import AsyncLock from 'async-lock';
 import crypto from 'crypto';
 
@@ -39,6 +39,7 @@ export default class VeSync {
     constructor(
         private readonly email: string,
         private readonly password: string,
+        readonly config: PlatformConfig,
         public readonly debugMode: DebugMode,
         public readonly log: Logger
     ) {
@@ -108,7 +109,11 @@ export default class VeSync {
             // Explicitly fail if device is offline
             if (response.data.msg == "device offline") {
                 this.log.error("VeSync cannot communicate with humidifier! Check the VeSync App.");
-                return false;
+                if (this.config.showOffWhenDisconnected) {
+                    return false;
+                } else {
+                    throw new Error("Device was unreachable. Ensure it is plugged in and connected to WiFi.")
+                }
             }
 
             if (!response?.data) {
@@ -158,7 +163,11 @@ export default class VeSync {
             // Explicitly fail if device is offline
             if (response.data.msg == "device offline") {
                 this.log.error("VeSync cannot communicate with humidifier! Check the VeSync App.");
-                return false;
+                if (this.config.showOffWhenDisconnected) {
+                    return false;
+                } else {
+                    throw new Error("Device was unreachable. Ensure it is plugged in and connected to WiFi.")
+                }
             }
 
             if (!response?.data) {

--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -109,7 +109,7 @@ export default class VeSync {
             // Explicitly fail if device is offline
             if (response.data.msg == "device offline") {
                 this.log.error("VeSync cannot communicate with humidifier! Check the VeSync App.");
-                if (this.config.showOffWhenDisconnected) {
+                if (this.config.options.showOffWhenDisconnected) {
                     return false;
                 } else {
                     throw new Error("Device was unreachable. Ensure it is plugged in and connected to WiFi.")
@@ -163,7 +163,7 @@ export default class VeSync {
             // Explicitly fail if device is offline
             if (response.data.msg == "device offline") {
                 this.log.error("VeSync cannot communicate with humidifier! Check the VeSync App.");
-                if (this.config.showOffWhenDisconnected) {
+                if (this.config.options.showOffWhenDisconnected) {
                     return false;
                 } else {
                     throw new Error("Device was unreachable. Ensure it is plugged in and connected to WiFi.")

--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -112,7 +112,7 @@ export default class VeSync {
                 if (this.config.options.showOffWhenDisconnected) {
                     return false;
                 } else {
-                    throw new Error("Device was unreachable. Ensure it is plugged in and connected to WiFi.")
+                    throw new Error("Device was unreachable. Ensure it is plugged in and connected to WiFi.");
                 }
             }
 
@@ -166,7 +166,7 @@ export default class VeSync {
                 if (this.config.options.showOffWhenDisconnected) {
                     return false;
                 } else {
-                    throw new Error("Device was unreachable. Ensure it is plugged in and connected to WiFi.")
+                    throw new Error("Device was unreachable. Ensure it is plugged in and connected to WiFi.");
                 }
             }
 

--- a/src/api/VeSyncFan.ts
+++ b/src/api/VeSyncFan.ts
@@ -279,7 +279,7 @@ export default class VeSyncFan {
                     this._brightnessLevel = 0;
                 }
                 else {
-                    throw new Error("Device was unreachable. Ensure it is plugged in and connected to WiFi.")
+                    throw new Error("Device was unreachable. Ensure it is plugged in and connected to WiFi.");
                 }
             }
         });

--- a/src/api/VeSyncFan.ts
+++ b/src/api/VeSyncFan.ts
@@ -101,6 +101,14 @@ export default class VeSyncFan {
                 this._warmLevel = 0;
                 this._brightnessLevel = 0;
             }
+        } else {
+            this._isOn = false;
+            this._humidityLevel = 0;
+            this._targetHumidity = 0;
+            this._displayOn = false;
+            this._mistLevel = 0;
+            this._warmLevel = 0;
+            this._brightnessLevel = 0;
         }
 
         return success;
@@ -232,6 +240,13 @@ export default class VeSyncFan {
                 this.lastCheck = Date.now();
 
                 if (!data?.result?.result) {
+                    this._isOn = false;
+                    this._humidityLevel = 0;
+                    this._targetHumidity = 0;
+                    this._displayOn = false;
+                    this._mistLevel = 0;
+                    this._warmLevel = 0;
+                    this._brightnessLevel = 0;
                     return;
                 }
 

--- a/src/api/VeSyncFan.ts
+++ b/src/api/VeSyncFan.ts
@@ -103,7 +103,7 @@ export default class VeSyncFan {
             }
         } else {
             this.client.log.error("Failed to setPower due to unreachable device.");
-            if (this.client.config.showOffWhenDisconnected) {
+            if (this.client.config.options.showOffWhenDisconnected) {
                 this._isOn = false;
                 this._humidityLevel = 0;
                 this._targetHumidity = 0;
@@ -243,7 +243,7 @@ export default class VeSyncFan {
 
                 const data = await this.client.getDeviceInfo(this);
                 this.lastCheck = Date.now();
-                if (!data?.result?.result && this.client.config.showOffWhenDisconnected) {
+                if (!data?.result?.result && this.client.config.options.showOffWhenDisconnected) {
                     this._isOn = false;
                     this._humidityLevel = 0;
                     this._targetHumidity = 0;
@@ -269,7 +269,7 @@ export default class VeSyncFan {
                 this._brightnessLevel = result.night_light_brightness;
             } catch (err: any) {
                 this.client.log.error("Failed to updateInfo due to unreachable device: " + err?.message);
-                if (this.client.config.showOffWhenDisconnected) {
+                if (this.client.config.options.showOffWhenDisconnected) {
                     this._isOn = false;
                     this._humidityLevel = 0;
                     this._targetHumidity = 0;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -42,7 +42,7 @@ export default class Platform implements DynamicPlatformPlugin {
     this.debugger = new DebugMode(!!enableDebugMode, this.log);
     this.debugger.debug('[PLATFORM]', 'Debug mode enabled');
 
-    this.client = new VeSync(email, password, this.debugger, log);
+    this.client = new VeSync(email, password, this.config, this.debugger, log);
 
     this.api.on('didFinishLaunching', () => {
       this.discoverDevices();


### PR DESCRIPTION
Fixes: 
- If device can't be contacted (disconnected from wifi, unplugged, etc.), return off values instead of `Not Responding`. Error message will display in HomeBridge logs when attempting to read / write values to device.