### PR TITLE
fix: Only return `undefined` when `result` is missing (not unconditionally)

### DIFF
--- a/src/api/VeSyncFan.ts
+++ b/src/api/VeSyncFan.ts
@@ -252,7 +252,7 @@ export default class VeSyncFan {
                     this._warmLevel = 0;
                     this._brightnessLevel = 0;
                     return;
-                } else {
+                } else if (!data?.result?.result) {
                     return;
                 }
 


### PR DESCRIPTION
Currently, in [`updateInfo`](https://github.com/pschroeder89/homebridge-levoit-humidifiers/blob/2bfec876f23160730908644f369b35760a11bba2/src/api/VeSyncFan.ts#L237-L286), the `else` case (empty `return`) is hit even when `data?.result?.result` exists (i.e. when device info was fetched successfully). I suspect this is not intended. This PR modifies the `else` condition so that it is not hit when data is fetched successfully.

I tracked this down after noticing the error below in my logs:
```
[homebridge-levoit-humidifiers] This plugin generated a warning from the characteristic 'Current Relative Humidity': characteristic value expected valid finite number and received "undefined" (undefined). See https://homebridge.io/w/JtMGR for more info.
```

This error was introduced in v1.7.1; it does not repro in v1.7.0. Specifically, the `if`/`else` conditions were modified in https://github.com/pschroeder89/homebridge-levoit-humidifiers/commit/2bfec876f23160730908644f369b35760a11bba2.

Aside: Although similar conditionals were added to [`setPower`](https://github.com/pschroeder89/homebridge-levoit-humidifiers/blob/2bfec876f23160730908644f369b35760a11bba2/src/api/VeSyncFan.ts#L86-L120), the same error isn’t present there, because the happy path (`success`) is checked first in that function.