### PR TITLE
Add the LUH-A601S-AUSW model as Classic 300S AUS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"
@@ -54,7 +54,8 @@
     "300s",
     "oasis",
     "lv600s",
-    "homebridge"
+    "homebridge",
+    "classic 300s"
   ],
   "types": "./dist/index.d.ts",
   "homepage": "https://github.com/pschroeder89/homebridge-levoit-humidifiers#readme",

--- a/src/api/deviceTypes.ts
+++ b/src/api/deviceTypes.ts
@@ -1,6 +1,7 @@
 export enum DeviceName {
   Classic300S = 'Classic300S',
   Classic300S_US = 'LUH-A601S-WUSB',
+  Classic300S_AUS = 'LUH-A601S-AUSW',
   Classic200S = 'Classic200S',
   Dual200S = 'Dual200S',
   Dual200S_LIGHT = 'LUH-D301S-WUSR',
@@ -67,6 +68,17 @@ const deviceTypes: DeviceType[] = [
   },
   {
     isValid: (input: string) => input.includes(DeviceName.Classic300S_US),
+    hasAutoMode: true,
+    mistLevels: 9,
+    hasLight: true,
+    hasColorMode: false,
+    hasSleepMode: true,
+    hasWarmMode: false,
+    minHumidityLevel: 30,
+    maxHumidityLevel: 80,
+  },
+  {
+    isValid: (input: string) => input.includes(DeviceName.Classic300S_AUS),
     hasAutoMode: true,
     mistLevels: 9,
     hasLight: true,


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pschroeder89/homebridge-levoit-humidifiers/pull/84?shareId=e4985e56-ae58-4761-b99e-21cda222c30c).