### PR TITLE
[codex] Clear stale RotationSpeed valid values on upgrade

### DIFF
--- a/src/VeSyncAccessory.ts
+++ b/src/VeSyncAccessory.ts
@@ -231,7 +231,13 @@ export default class VeSyncAccessory {
 
     service
       .getCharacteristic(this.platform.Characteristic.RotationSpeed)
-      .setProps({ minStep: 1, minValue: 0, maxValue: 100 })
+      .setProps({
+        minStep: 1,
+        minValue: 0,
+        maxValue: 100,
+        validValues: null,
+        validValueRanges: null,
+      })
       .onGet(MistLevel.get.bind(this))
       .onSet(MistLevel.set.bind(this));
 
@@ -304,7 +310,13 @@ export default class VeSyncAccessory {
 
     service
       .getCharacteristic(this.platform.Characteristic.RotationSpeed)
-      .setProps({ minStep: 1, minValue: 0, maxValue: 100 })
+      .setProps({
+        minStep: 1,
+        minValue: 0,
+        maxValue: 100,
+        validValues: null,
+        validValueRanges: null,
+      })
       .onGet(WarmMistLevel.get.bind(this))
       .onSet(WarmMistLevel.set.bind(this));
 


### PR DESCRIPTION
## What changed
Clear stale `validValues` and `validValueRanges` on the Mist and Warm Mist `RotationSpeed` characteristics.

## Why
Recent beta builds report `RotationSpeed` as a 0-100 percentage. Existing Homebridge accessory caches can still carry the old discrete `validValues` arrays from earlier plugin versions, which causes warnings like `characteristic value 56 is not contained in valid values array` after upgrade.

## Impact
Upgrades from older Levoit plugin builds no longer retain stale discrete valid-value metadata for mist sliders.

## Root cause
`setProps` only clears `validValues` when the plugin explicitly passes `null`. The beta code switched `RotationSpeed` to percentages but did not explicitly reset the previous discrete valid-values metadata.

## Validation
- `npm run build`
- `npm run lint`
- verified on a live Homebridge child bridge that stale cached `validValues` arrays were the trigger for the warning
