### PR TITLE
Fix warm mist sync, target humidity 0% flash, add custom polling interval

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,7 @@
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
         "project": [
-            "./tsconfig.json"
+            "./tsconfig.eslint.json"
         ]
     },
     "plugins": [

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Lint
+name: Build, Lint, and Test
 
 on:
   push:
@@ -27,6 +27,9 @@ jobs:
 
       - name: Lint the project
         run: yarn lint
+
+      - name: Run tests
+        run: yarn test
 
       - name: Build the project
         run: yarn build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '26 12 * * 6'
 

--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ src
 
 # typescript
 tsconfig.json
+tsconfig.eslint.json
 
 # vscode
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [1.22.0-beta.1] - 2026-Jul-12
+
+### Fixed
+
+- #104: Warm mist wasn't syncing on new-format devices (e.g. LUH-A603S) - both the command payload shape and the background-polling read path were wrong for these devices.
+- #102: Target humidity flashed 0% on power-on instead of showing the last known value.
+- LV600S mode-string bug: only the newer LUH-A603S uses `"humidity"` as its Auto-equivalent mode; the older LUH-A602S uses plain `"auto"`. Both were incorrectly sent `"humidity"`.
+- `yarn lint` was silently skipping most of `src/` (everything under `api/`, `characteristics/`, `utils/`) due to a non-recursive glob.
+- CodeQL push/PR scanning was silently disabled - the workflow targeted the nonexistent `master` branch instead of `main`.
+
+### Added
+
+- #106: `options.pollingInterval` config to reduce VeSync polling frequency.
+- #99: Superior 6000S's target humidity slider can now reach Humidity (Smart) mode instead of always forcing AutoPro.
+- `LEH-S602S-WUS` device support (Superior 6000S variant).
+- NeoClassic 450S added to the supported-devices table in the README.
+
+### Changed
+
+- Upgraded `axios` from `0.24.0` to `1.18.1`.
+- Enabled `noImplicitAny` and bumped the TypeScript build target to ES2022 (matching the `node >=20.19.0` engine requirement).
+
 ## [1.15.0] - 2025-Sept-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ Via config.json:
       },
       "options": {
         "enableDebugMode": false,
-        "showOffWhenDisconnected": false
+        "showOffWhenDisconnected": false,
+        "pollingInterval": 30
       }
     }
   ]
@@ -137,6 +138,12 @@ for it to display back in HomeKit.
 If you prefer the disconnected device to be visible in HomeKit at all times,
 set `showOffWhenDisconnected` to `true` in the config. The humidifiers will remain in HomeKit in an Off state.
 **Note: This will cause benign errors in the Homebridge logs that the device could not be contacted.**
+
+### Custom Polling Interval
+
+The plugin polls VeSync every 30 seconds by default to keep HomeKit in sync with your device(s). VeSync enforces a daily
+API quota, so if you're also polling your devices from another integration (e.g. Hubitat) and exceeding that quota, you
+can slow down polling by setting `pollingInterval` (in seconds, minimum 10) in the `options` section of your config.
 
 ### Enabling Debug Mode
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is a Homebridge plugin to control Levoit Humidifiers from Apple HomeKit.
 | OasisMist 600S     | ✅              | ✅   | ✅    | ❌    | ✅      | ✅   |
 | OasisMist 450S     | ✅              | ✅   | ✅    | ❌    | ✅      | ✅   |
 | LV600S             | ✅              | ✅   | ✅    | ❌    | ✅      | ✅   |
+| NeoClassic 450S    | ✅              | ✅   | ✅    | ✅    | ✅      | ❌   |
 | Classic 300S       | ✅              | ✅   | ✅    | ✅    | ✅      | ❌   |
 | Classic 200S       | ✅              | ✅   | ❌    | ❌    | ✅      | ❌   |
 | Dual 200S          | ✅              | ✅   | ❌    | ✅    | ✅      | ❌   |

--- a/config.schema.json
+++ b/config.schema.json
@@ -84,6 +84,13 @@
             "type": "boolean",
             "default": false,
             "description": "When set to true, HomeKit will display unresponsive humidifiers as Off instead of Not Responding. Read the \"Note to Seasonal Humidifier Users\" in the README for more info."
+          },
+          "pollingInterval": {
+            "title": "Polling Interval (seconds)",
+            "type": "integer",
+            "default": 30,
+            "minimum": 10,
+            "description": "How often (in seconds) to poll VeSync for device status updates. Increase this if you're sharing your VeSync API quota with another integration (e.g. Hubitat) and hitting daily request limits. Minimum 10 seconds."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "async-lock": "^1.3.0",
-    "axios": "^0.24.0",
+    "axios": "^1.18.1",
     "uuid": "^9.0.0"
   },
   "keywords": [
@@ -55,8 +55,7 @@
     "300s",
     "oasis",
     "lv600s",
-    "homebridge",
-    "classic 300s"
+    "homebridge"
   ],
   "types": "./dist/index.d.ts",
   "homepage": "https://github.com/pschroeder89/homebridge-levoit-humidifiers#readme",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.22.0-beta.0",
+  "version": "1.22.0-beta.1",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.20.0-beta.21",
+  "version": "1.21.1-beta.0",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/async-lock": "^1.1.3",
     "@types/node": "^16.11.7",
+    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^8.52.0",
     "@typescript-eslint/parser": "^8.52.0",
     "eslint": "^8.57.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.21.1-beta.0",
+  "version": "1.22.0-beta.0",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
   },
   "scripts": {
     "remove-link": "npm -g remove homebridge-levoit-humidifiers",
-    "prepublishOnly": "npm run lint && npm run build",
+    "prepublishOnly": "npm run lint && npm run test && npm run build",
     "watch": "npm run build && npm link && nodemon",
     "lint": "eslint src/**/*.ts --max-warnings=0",
+    "test": "node --require ts-node/register --test $(find src -name '*.spec.ts')",
     "build": "rimraf ./dist && tsc"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.22.0-beta.1",
+  "version": "1.22.0",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "remove-link": "npm -g remove homebridge-levoit-humidifiers",
     "prepublishOnly": "npm run lint && npm run build",
     "watch": "npm run build && npm link && nodemon",
-    "lint": "eslint src/**.ts --max-warnings=0",
+    "lint": "eslint src/**/*.ts --max-warnings=0",
     "build": "rimraf ./dist && tsc"
   },
   "devDependencies": {

--- a/src/VeSyncAccessory.ts
+++ b/src/VeSyncAccessory.ts
@@ -51,12 +51,13 @@ export default class VeSyncAccessory {
 
   /**
    * Background polling interval to keep device state fresh.
-   * Polls every 30 seconds to balance freshness with API quota limits.
-   * The VeSync API has daily quotas (3200 + 1500 * device count), so we
-   * need to be conservative with polling frequency.
+   * Defaults to 30 seconds to balance freshness with API quota limits, but can be
+   * overridden via options.pollingInterval in the config for users hitting VeSync's
+   * daily quota (3200 + 1500 * device count), e.g. when sharing quota with another integration.
+   * Clamped to a 10-second minimum to avoid hammering the API.
    */
   private pollingInterval: NodeJS.Timeout | null = null;
-  private readonly POLLING_INTERVAL_MS = 30000; // 30 seconds
+  private readonly POLLING_INTERVAL_MS: number;
 
   public get UUID() {
     return this.device.uuid.toString();
@@ -72,6 +73,11 @@ export default class VeSyncAccessory {
   ) {
     const config = platform.config;
     const accessories = config.accessories ? config.accessories : {};
+    const configuredPollingSeconds = Number(config.options?.pollingInterval);
+    this.POLLING_INTERVAL_MS =
+      (Number.isFinite(configuredPollingSeconds) && configuredPollingSeconds > 0
+        ? Math.max(configuredPollingSeconds, 10)
+        : 30) * 1000;
 
     this.setupAccessoryInfo();
     this.humidifierService = this.setupHumidifierService();
@@ -452,7 +458,7 @@ export default class VeSyncAccessory {
       .getCharacteristic(
         this.platform.Characteristic.RelativeHumidityHumidifierThreshold,
       )
-      .updateValue(device.isOn ? device.targetHumidity : 0);
+      .updateValue(device.targetHumidity);
 
     this.humidifierService
       .getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)

--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -174,7 +174,7 @@ interface LoginResponse {
   };
 }
 
-interface DeviceResult {
+export interface DeviceResult {
   humidity?: number;
   targetHumidity?: number;
   screenSwitch?: boolean;
@@ -207,7 +207,7 @@ interface DeviceResult {
   };
 }
 
-interface DeviceInfoResponse {
+export interface DeviceInfoResponse {
   result?: {
     result?: DeviceResult;
   };

--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -8,7 +8,7 @@ import * as path from 'node:path';
 
 import deviceTypes from './deviceTypes';
 import DebugMode from '../debugMode';
-import VeSyncFan from './VeSyncFan';
+import VeSyncFan, { DeviceListItem } from './VeSyncFan';
 
 /**
  * VeSync API bypass methods for device control.
@@ -1246,7 +1246,7 @@ export default class VeSync {
         JSON.stringify(list),
       );
 
-      const devices = list
+      const devices = (list as DeviceListItem[])
         .filter(
           ({ deviceType, type }) =>
             deviceTypes.some(({ isValid }) => isValid(deviceType)) &&

--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -192,6 +192,8 @@ interface DeviceResult {
   mist_virtual_level?: number;
   warm_level?: number;
   warm_enabled?: boolean;
+  warmLevel?: number;
+  warmPower?: boolean;
   night_light_brightness?: number;
   rgbNightLight?: {
     brightness?: number;

--- a/src/api/VeSyncFan.spec.ts
+++ b/src/api/VeSyncFan.spec.ts
@@ -1,0 +1,458 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { Logger, PlatformConfig } from 'homebridge';
+
+import VeSync, { BypassMethod, DeviceInfoResponse } from './VeSync';
+import VeSyncFan, { DeviceListItem, Mode } from './VeSyncFan';
+import DebugMode from '../debugMode';
+
+/**
+ * Tests for VeSyncFan's command-building logic: the exact JSON payload
+ * shape and bypass method sent for each device generation. This is the
+ * area of the codebase most prone to silent regressions - VeSync's API
+ * accepts nearly any payload shape with a 200/code:0 response even when
+ * the device ignores it, so a wrong field name here fails silently in
+ * production and only surfaces as a user bug report weeks later.
+ */
+
+const NOOP_LOGGER: Logger = {
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  debug: () => undefined,
+  log: () => undefined,
+} as unknown as Logger;
+
+function createClient(configOverrides: Partial<PlatformConfig> = {}): VeSync {
+  const config = {
+    options: {},
+    ...configOverrides,
+  } as PlatformConfig;
+  const debugMode = new DebugMode(false, NOOP_LOGGER);
+  return new VeSync(
+    'test@example.com',
+    'password',
+    config,
+    debugMode,
+    NOOP_LOGGER,
+  );
+}
+
+interface CapturedCommand {
+  method: BypassMethod;
+  body: Record<string, unknown>;
+}
+
+/** Replaces VeSync.sendCommand with a spy and returns the calls it captures. */
+function stubSendCommand(
+  client: VeSync,
+  result = true,
+): { calls: CapturedCommand[] } {
+  const calls: CapturedCommand[] = [];
+  (client as unknown as { sendCommand: VeSync['sendCommand'] }).sendCommand =
+    async (_fan, method, body = {}) => {
+      calls.push({ method, body });
+      return result;
+    };
+  return { calls };
+}
+
+/** Replaces VeSync.getDeviceInfo with a spy that resolves to the given response. */
+function stubGetDeviceInfo(
+  client: VeSync,
+  response: DeviceInfoResponse | null,
+): void {
+  (
+    client as unknown as { getDeviceInfo: VeSync['getDeviceInfo'] }
+  ).getDeviceInfo = async () => response;
+}
+
+function deviceListFixture(
+  overrides: Partial<DeviceListItem> = {},
+): DeviceListItem {
+  return {
+    deviceName: 'Test Device',
+    mode: Mode.Manual,
+    deviceStatus: true,
+    mistLevel: 0,
+    warmLevel: 0,
+    warmEnabled: false,
+    brightnessLevel: 0,
+    humidity: 50,
+    targetHumidity: 55,
+    targetReached: false,
+    lightOn: 'off',
+    lightSpeed: 0,
+    red: 255,
+    blue: 255,
+    green: 255,
+    colorMode: 'white',
+    colorSliderLocation: 0,
+    configModule: 'test-config-module',
+    cid: 'test-cid',
+    deviceRegion: 'US',
+    deviceType: 'LUH-A601S-WUSB',
+    macID: 'AA:BB:CC:DD:EE:FF',
+    uuid: 'test-uuid',
+    type: 'wifi-air',
+    ...overrides,
+  };
+}
+
+function createFan(
+  client: VeSync,
+  deviceType: string,
+  overrides: Partial<DeviceListItem> = {},
+): VeSyncFan {
+  return VeSyncFan.fromResponse(client)(
+    deviceListFixture({ deviceType, ...overrides }),
+  );
+}
+
+// Representative model prefixes for each format/family under test.
+const CLASSIC_300S = 'LUH-A601S-WUSB'; // old format, no warm mist
+const LV600S_OLD = 'LUH-A602S-WUS'; // old format, has warm mist
+const LV600S_NEW = 'LUH-A603S-WUS'; // new format, has warm mist
+const SUPERIOR_6000S = 'LEH-S601S-WUS'; // new format, AutoPro, no warm mist
+const NEOCLASSIC_450S = 'LUH-N451S-WUS'; // new format, no warm mist
+
+describe('VeSyncFan.setPower', () => {
+  it('sends the old-format payload for pre-A603S devices', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, LV600S_OLD);
+
+    await fan.setPower(true);
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].method, BypassMethod.SWITCH);
+    assert.deepEqual(calls[0].body, { enabled: true, id: 0 });
+  });
+
+  it('sends the new-format payload for new-format devices', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, LV600S_NEW);
+
+    await fan.setPower(false);
+
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].body, { powerSwitch: 0, id: 0 });
+  });
+
+  it('retains targetHumidity across power-off instead of zeroing it', async () => {
+    const client = createClient();
+    stubSendCommand(client);
+    const fan = createFan(client, CLASSIC_300S, { targetHumidity: 62 });
+
+    await fan.setPower(false);
+
+    assert.equal(
+      fan.targetHumidity,
+      62,
+      'targetHumidity should be retained so HomeKit does not flash 0%',
+    );
+  });
+
+  it('restores the last known targetHumidity when turning back on from a zeroed state', async () => {
+    const client = createClient();
+    stubSendCommand(client);
+    // Start already off with a retained target from a prior power-off.
+    const fan = createFan(client, CLASSIC_300S, { targetHumidity: 62 });
+    await fan.setPower(false);
+    // Simulate a fresh poll reporting the device as off with humidity zeroed,
+    // which is how a real restart/poll cycle could observe it.
+    await fan.setPower(true);
+
+    assert.equal(fan.targetHumidity, 62);
+  });
+});
+
+describe('VeSyncFan.setTargetHumidity', () => {
+  it('sends the old-format payload', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, CLASSIC_300S);
+
+    await fan.setTargetHumidity(50);
+
+    assert.equal(calls[0].method, BypassMethod.HUMIDITY);
+    assert.deepEqual(calls[0].body, { target_humidity: 50, id: 0 });
+  });
+
+  it('sends the new-format payload', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, NEOCLASSIC_450S);
+
+    await fan.setTargetHumidity(50);
+
+    assert.deepEqual(calls[0].body, { targetHumidity: 50, id: 0 });
+  });
+});
+
+describe('VeSyncFan.changeMode', () => {
+  it('does not remap Auto to Humidity for the old-format LUH-A602S', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, LV600S_OLD, { mode: Mode.Manual });
+
+    await fan.changeMode(Mode.Auto);
+
+    assert.equal(calls[0].method, BypassMethod.MODE);
+    assert.deepEqual(calls[0].body, { mode: 'auto' });
+    assert.equal(fan.mode, Mode.Auto);
+  });
+
+  it('remaps Auto to Humidity for the new-format LUH-A603S', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, LV600S_NEW, { mode: Mode.Manual });
+
+    await fan.changeMode(Mode.Auto);
+
+    assert.deepEqual(calls[0].body, { workMode: 'humidity' });
+    assert.equal(fan.mode, Mode.Humidity);
+  });
+
+  it('remaps Auto to AutoPro for AutoPro-capable devices', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, SUPERIOR_6000S, { mode: Mode.Manual });
+
+    await fan.changeMode(Mode.Auto);
+
+    assert.deepEqual(calls[0].body, { workMode: 'autoPro' });
+    assert.equal(fan.mode, Mode.AutoPro);
+  });
+
+  it('skips the API call when already in the requested mode', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, CLASSIC_300S, { mode: Mode.Sleep });
+
+    const success = await fan.changeMode(Mode.Sleep);
+
+    assert.equal(success, true);
+    assert.equal(calls.length, 0);
+  });
+});
+
+describe('VeSyncFan.changeMistLevel', () => {
+  it('rejects a level above the device maximum without calling the API', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, CLASSIC_300S); // mistLevels: 9
+
+    const success = await fan.changeMistLevel(10);
+
+    assert.equal(success, false);
+    assert.equal(calls.length, 0);
+  });
+
+  it('rejects level 0 (use setPower(false) to turn off instead)', async () => {
+    const client = createClient();
+    stubSendCommand(client);
+    const fan = createFan(client, CLASSIC_300S);
+
+    assert.equal(await fan.changeMistLevel(0), false);
+  });
+
+  it('sends the old-format payload', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, CLASSIC_300S);
+
+    await fan.changeMistLevel(5);
+
+    assert.equal(calls[0].method, BypassMethod.MIST_LEVEL);
+    assert.deepEqual(calls[0].body, { level: 5, type: 'mist', id: 0 });
+  });
+
+  it('sends the new-format payload', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, LV600S_NEW);
+
+    await fan.changeMistLevel(5);
+
+    assert.deepEqual(calls[0].body, {
+      virtualLevel: 5,
+      levelType: 'mist',
+      id: 0,
+    });
+  });
+});
+
+describe('VeSyncFan.changeWarmMistLevel', () => {
+  it('rejects devices without warm mist support', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, CLASSIC_300S); // no warmMistLevels
+
+    const success = await fan.changeWarmMistLevel(1);
+
+    assert.equal(success, false);
+    assert.equal(calls.length, 0);
+  });
+
+  it('rejects an out-of-range level', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, LV600S_OLD); // warmMistLevels: 3
+
+    assert.equal(await fan.changeWarmMistLevel(4), false);
+    assert.equal(calls.length, 0);
+  });
+
+  it('sends the old-format payload via setLevel', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, LV600S_OLD);
+
+    await fan.changeWarmMistLevel(2);
+
+    assert.equal(calls[0].method, BypassMethod.LEVEL);
+    assert.deepEqual(calls[0].body, { level: 2, type: 'warm', id: 0 });
+  });
+
+  it('sends the corrected new-format payload for LUH-A603S (regression guard for #104)', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, LV600S_NEW);
+
+    await fan.changeWarmMistLevel(2);
+
+    // This is NOT a virtualLevel/setVirtualLevel command like cool mist -
+    // confirmed against pyvesync's dedicated LV600S class. Getting this
+    // wrong doesn't error, it just gets silently ignored by the device.
+    assert.equal(calls[0].method, BypassMethod.LEVEL);
+    assert.deepEqual(calls[0].body, {
+      levelIdx: 0,
+      levelType: 'warm',
+      mistLevel: 0,
+      warmLevel: 2,
+    });
+  });
+
+  it('updates warmEnabled based on the resulting level', async () => {
+    const client = createClient();
+    stubSendCommand(client);
+    const fan = createFan(client, LV600S_OLD);
+
+    await fan.changeWarmMistLevel(2);
+    assert.equal(fan.warmEnabled, true);
+
+    await fan.changeWarmMistLevel(0);
+    assert.equal(fan.warmEnabled, false);
+  });
+});
+
+describe('VeSyncFan.setDisplay', () => {
+  it('sends the old-format payload', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, CLASSIC_300S);
+
+    await fan.setDisplay(true);
+
+    assert.deepEqual(calls[0].body, { state: true, id: 0 });
+  });
+
+  it('sends the new-format payload', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, NEOCLASSIC_450S);
+
+    await fan.setDisplay(true);
+
+    assert.deepEqual(calls[0].body, { screenSwitch: 1, id: 0 });
+  });
+});
+
+describe('VeSyncFan.updateInfo', () => {
+  it('reads warm mist state from camelCase keys for new-format devices (regression guard for #104)', async () => {
+    const client = createClient();
+    const fan = createFan(client, LV600S_NEW);
+    stubGetDeviceInfo(client, {
+      result: {
+        result: {
+          powerSwitch: 1,
+          workMode: 'manual',
+          targetHumidity: 55,
+          humidity: 50,
+          virtualLevel: 3,
+          screenSwitch: true,
+          autoStopState: false,
+          // camelCase - what LUH-A603S actually returns
+          warmLevel: 2,
+          warmPower: true,
+        },
+      },
+    });
+
+    await fan.updateInfo();
+
+    assert.equal(
+      fan.warmLevel,
+      2,
+      'should read warmLevel, not fall back to 0 via the snake_case key',
+    );
+    assert.equal(fan.warmEnabled, true);
+  });
+
+  it('reads warm mist state from snake_case keys for old-format devices', async () => {
+    const client = createClient();
+    const fan = createFan(client, LV600S_OLD);
+    stubGetDeviceInfo(client, {
+      result: {
+        result: {
+          enabled: true,
+          mode: 'manual',
+          humidity: 50,
+          mist_virtual_level: 3,
+          display: true,
+          automatic_stop_reach_target: false,
+          configuration: { auto_target_humidity: 55 },
+          warm_level: 1,
+          warm_enabled: true,
+        },
+      },
+    });
+
+    await fan.updateInfo();
+
+    assert.equal(fan.warmLevel, 1);
+    assert.equal(fan.warmEnabled, true);
+  });
+
+  it('does not misread new-format camelCase warm keys as the old-format fields', async () => {
+    const client = createClient();
+    const fan = createFan(client, LV600S_OLD, {
+      warmLevel: 3,
+      warmEnabled: true,
+    });
+    // An old-format device response should never contain warmLevel/warmPower,
+    // but if it somehow did, the old-format branch must ignore them.
+    stubGetDeviceInfo(client, {
+      result: {
+        result: {
+          enabled: true,
+          mode: 'manual',
+          humidity: 50,
+          mist_virtual_level: 3,
+          display: true,
+          automatic_stop_reach_target: false,
+          configuration: { auto_target_humidity: 55 },
+          warmLevel: 99,
+          warmPower: true,
+        },
+      },
+    });
+
+    await fan.updateInfo();
+
+    assert.equal(fan.warmLevel, 0);
+    assert.equal(fan.warmEnabled, false);
+  });
+});

--- a/src/api/VeSyncFan.ts
+++ b/src/api/VeSyncFan.ts
@@ -242,8 +242,9 @@ export default class VeSyncFan {
    * @returns true if successful, false otherwise
    */
   public async changeMode(mode: Mode): Promise<boolean> {
-    // LV600s models use "Humidity" mode instead of "Auto"
-    if (isLV600S(this.model) && mode == Mode.Auto) {
+    // Only the newer LUH-A603S uses "Humidity" as its Auto-equivalent workMode;
+    // the older LUH-A602S uses plain "auto" (confirmed against pyvesync's device map).
+    if (isLV600S(this.model) && isNewFormatDevice(this.model) && mode == Mode.Auto) {
       mode = Mode.Humidity;
     }
     // Some models use "AutoPro" mode instead of "Auto"
@@ -408,16 +409,17 @@ export default class VeSyncFan {
 
     this.client.log.info('Setting Warm Level to ' + warmMistLevel);
 
-    // New models use different JSON keys (matches changeMistLevel's format handling)
+    // New-format devices (currently just LUH-A603S) use a distinct payload shape
+    // for warm level, confirmed against pyvesync's dedicated LV600S class: unlike
+    // cool mist, it is NOT a virtualLevel/setVirtualLevel command.
     let warmJson;
-    let method = BypassMethod.LEVEL;
     if (isNewFormatDevice(this.model)) {
       warmJson = {
-        virtualLevel: warmMistLevel,
+        levelIdx: 0,
         levelType: 'warm',
-        id: 0,
+        mistLevel: 0,
+        warmLevel: warmMistLevel,
       };
-      method = BypassMethod.MIST_LEVEL;
     } else {
       warmJson = {
         level: warmMistLevel,
@@ -426,7 +428,11 @@ export default class VeSyncFan {
       };
     }
 
-    const success = await this.client.sendCommand(this, method, warmJson);
+    const success = await this.client.sendCommand(
+      this,
+      BypassMethod.LEVEL,
+      warmJson,
+    );
 
     if (success) {
       this._warmLevel = warmMistLevel;
@@ -556,8 +562,17 @@ export default class VeSyncFan {
           this._mistLevel = (result.mist_virtual_level as number) ?? 0;
         }
 
-        this._warmLevel = (result.warm_level as number) ?? 0;
-        this._warmEnabled = (result.warm_enabled as boolean) ?? false;
+        // New-format devices (currently just LUH-A603S) return warm mist state
+        // under camelCase keys (warmLevel/warmPower) instead of the old
+        // snake_case ones - reading the wrong keys silently kept warm mist
+        // state stuck at 0/off after every poll, regardless of device state.
+        if (isNewFormatDevice(this.model)) {
+          this._warmLevel = (result.warmLevel as number) ?? 0;
+          this._warmEnabled = (result.warmPower as boolean) ?? false;
+        } else {
+          this._warmLevel = (result.warm_level as number) ?? 0;
+          this._warmEnabled = (result.warm_enabled as boolean) ?? false;
+        }
 
         this._brightnessLevel =
           ((result.night_light_brightness ??

--- a/src/api/VeSyncFan.ts
+++ b/src/api/VeSyncFan.ts
@@ -16,6 +16,37 @@ export enum Mode {
 }
 
 /**
+ * Shape of a single entry in the VeSync device list API response
+ * (cloud/v2/deviceManaged/devices), for devices of type 'wifi-air'.
+ */
+export interface DeviceListItem {
+  deviceName: string;
+  mode: Mode;
+  deviceStatus: boolean;
+  mistLevel: number;
+  warmLevel: number;
+  warmEnabled: boolean;
+  brightnessLevel: number;
+  humidity: number;
+  targetHumidity: number;
+  targetReached: boolean;
+  lightOn: string;
+  lightSpeed: number;
+  red: number;
+  blue: number;
+  green: number;
+  colorMode: string;
+  colorSliderLocation: number;
+  configModule: string;
+  cid: string;
+  deviceRegion: string;
+  deviceType: string;
+  macID: string;
+  uuid: string;
+  type: string;
+}
+
+/**
  * VeSyncFan represents a single Levoit humidifier device.
  * Manages device state, API communication, and provides methods to control the device.
  */
@@ -657,7 +688,7 @@ export default class VeSyncFan {
       deviceType,
       macID,
       uuid,
-    }) =>
+    }: DeviceListItem) =>
       new VeSyncFan(
         client,
         deviceName,

--- a/src/api/VeSyncFan.ts
+++ b/src/api/VeSyncFan.ts
@@ -244,7 +244,11 @@ export default class VeSyncFan {
   public async changeMode(mode: Mode): Promise<boolean> {
     // Only the newer LUH-A603S uses "Humidity" as its Auto-equivalent workMode;
     // the older LUH-A602S uses plain "auto" (confirmed against pyvesync's device map).
-    if (isLV600S(this.model) && isNewFormatDevice(this.model) && mode == Mode.Auto) {
+    if (
+      isLV600S(this.model) &&
+      isNewFormatDevice(this.model) &&
+      mode == Mode.Auto
+    ) {
       mode = Mode.Humidity;
     }
     // Some models use "AutoPro" mode instead of "Auto"

--- a/src/api/VeSyncFan.ts
+++ b/src/api/VeSyncFan.ts
@@ -158,12 +158,13 @@ export default class VeSyncFan {
     if (success) {
       this._isOn = power;
       if (!this._isOn) {
-        // When turning off, save current target and reset all state to match device behavior
+        // When turning off, save current target and reset all state to match device behavior.
+        // targetHumidity is intentionally retained (not zeroed) so HomeKit continues to
+        // display the last known value instead of flashing 0% while the device is off.
         if (this._targetHumidity > 0) {
           this._lastTargetHumidity = this._targetHumidity;
         }
         this._humidityLevel = 0;
-        this._targetHumidity = 0;
         this._mistLevel = 0;
         this._warmLevel = 0;
         this._warmEnabled = false;
@@ -407,11 +408,25 @@ export default class VeSyncFan {
 
     this.client.log.info('Setting Warm Level to ' + warmMistLevel);
 
-    const success = await this.client.sendCommand(this, BypassMethod.LEVEL, {
-      level: warmMistLevel,
-      type: 'warm',
-      id: 0,
-    });
+    // New models use different JSON keys (matches changeMistLevel's format handling)
+    let warmJson;
+    let method = BypassMethod.LEVEL;
+    if (isNewFormatDevice(this.model)) {
+      warmJson = {
+        virtualLevel: warmMistLevel,
+        levelType: 'warm',
+        id: 0,
+      };
+      method = BypassMethod.MIST_LEVEL;
+    } else {
+      warmJson = {
+        level: warmMistLevel,
+        type: 'warm',
+        id: 0,
+      };
+    }
+
+    const success = await this.client.sendCommand(this, method, warmJson);
 
     if (success) {
       this._warmLevel = warmMistLevel;

--- a/src/api/VeSyncFan.ts
+++ b/src/api/VeSyncFan.ts
@@ -159,6 +159,15 @@ export default class VeSyncFan {
   private _lastTargetHumidity = 0;
 
   /**
+   * Picks the new-format or old-format command payload for this device.
+   * Most set-commands need entirely different JSON field names between newer
+   * devices (camelCase, e.g. LUH-N451S-, LUH-A603S-) and older ones (snake_case).
+   */
+  private formatPayload<T>(newFormat: T, oldFormat: T): T {
+    return isNewFormatDevice(this.model) ? newFormat : oldFormat;
+  }
+
+  /**
    * Sets the device power state (on/off).
    * When turning off, resets related state values to 0.
    * When turning on, restores the last known target humidity from memory.
@@ -168,18 +177,10 @@ export default class VeSyncFan {
    */
   public async setPower(power: boolean): Promise<boolean> {
     this.client.log.info('Setting Power to ' + power);
-    let switchJson;
-    if (isNewFormatDevice(this.model)) {
-      switchJson = {
-        powerSwitch: power ? 1 : 0,
-        id: 0,
-      };
-    } else {
-      switchJson = {
-        enabled: power,
-        id: 0,
-      };
-    }
+    const switchJson = this.formatPayload(
+      { powerSwitch: power ? 1 : 0, id: 0 },
+      { enabled: power, id: 0 },
+    );
     const success = await this.client.sendCommand(
       this,
       BypassMethod.SWITCH,
@@ -236,18 +237,10 @@ export default class VeSyncFan {
     this.client.log.info('Setting Target Humidity to ' + level);
 
     // Oasis 1000 uses camelcase instead of snakecase
-    let humidityJson;
-    if (isNewFormatDevice(this.model)) {
-      humidityJson = {
-        targetHumidity: level,
-        id: 0,
-      };
-    } else {
-      humidityJson = {
-        target_humidity: level,
-        id: 0,
-      };
-    }
+    const humidityJson = this.formatPayload(
+      { targetHumidity: level, id: 0 },
+      { target_humidity: level, id: 0 },
+    );
 
     const success = await this.client.sendCommand(
       this,
@@ -290,16 +283,10 @@ export default class VeSyncFan {
     let success: boolean;
 
     // Oasis 1000 uses camelcase instead of snakecase
-    let modeJson;
-    if (isNewFormatDevice(this.model)) {
-      modeJson = {
-        workMode: mode.toString(),
-      };
-    } else {
-      modeJson = {
-        mode: mode.toString(),
-      };
-    }
+    const modeJson = this.formatPayload(
+      { workMode: mode.toString() },
+      { mode: mode.toString() },
+    );
     // Don't change the mode if we are already in that mode
     if (this._mode == mode) {
       success = true;
@@ -354,18 +341,10 @@ export default class VeSyncFan {
     this.client.log.info('Setting Display to ' + power);
 
     // Oasis 1000 uses camelcase instead of snakecase
-    let displayJson;
-    if (isNewFormatDevice(this.model)) {
-      displayJson = {
-        screenSwitch: power ? 1 : 0,
-        id: 0,
-      };
-    } else {
-      displayJson = {
-        state: power,
-        id: 0,
-      };
-    }
+    const displayJson = this.formatPayload(
+      { screenSwitch: power ? 1 : 0, id: 0 },
+      { state: power, id: 0 },
+    );
 
     const success = await this.client.sendCommand(
       this,
@@ -396,23 +375,16 @@ export default class VeSyncFan {
     this.client.log.info('Setting Mist Level to ' + mistLevel);
 
     // New models use different JSON keys
-    let mistJson;
-    const method = BypassMethod.MIST_LEVEL;
-    if (isNewFormatDevice(this.model)) {
-      mistJson = {
-        virtualLevel: mistLevel,
-        levelType: 'mist',
-        id: 0,
-      };
-    } else {
-      mistJson = {
-        level: mistLevel,
-        type: 'mist',
-        id: 0,
-      };
-    }
+    const mistJson = this.formatPayload(
+      { virtualLevel: mistLevel, levelType: 'mist', id: 0 },
+      { level: mistLevel, type: 'mist', id: 0 },
+    );
 
-    const success = await this.client.sendCommand(this, method, mistJson);
+    const success = await this.client.sendCommand(
+      this,
+      BypassMethod.MIST_LEVEL,
+      mistJson,
+    );
 
     if (success) {
       this._mistLevel = mistLevel;
@@ -447,21 +419,15 @@ export default class VeSyncFan {
     // New-format devices (currently just LUH-A603S) use a distinct payload shape
     // for warm level, confirmed against pyvesync's dedicated LV600S class: unlike
     // cool mist, it is NOT a virtualLevel/setVirtualLevel command.
-    let warmJson;
-    if (isNewFormatDevice(this.model)) {
-      warmJson = {
+    const warmJson = this.formatPayload(
+      {
         levelIdx: 0,
         levelType: 'warm',
         mistLevel: 0,
         warmLevel: warmMistLevel,
-      };
-    } else {
-      warmJson = {
-        level: warmMistLevel,
-        type: 'warm',
-        id: 0,
-      };
-    }
+      },
+      { level: warmMistLevel, type: 'warm', id: 0 },
+    );
 
     const success = await this.client.sendCommand(
       this,

--- a/src/api/deviceTypes.ts
+++ b/src/api/deviceTypes.ts
@@ -9,6 +9,7 @@ export enum DevicePrefix {
   OASIS_1000S = 'LUH-M101S-',
   NeoClassic450S = 'LUH-N451S-',
   LEH_S601S = 'LEH-S601S-',
+  LEH_S602S = 'LEH-S602S-',
   O601S = 'LUH-O601S-',
 }
 
@@ -17,10 +18,18 @@ export const LV600S_PREFIXES = [
   DevicePrefix.LV600S_V2,
 ] as const;
 
+// Superior 6000S is sold under both the LEH-S601S and LEH-S602S hardware prefixes;
+// both share the same feature set and mode strings.
+export const SUPERIOR_6000S_PREFIXES = [
+  DevicePrefix.LEH_S601S,
+  DevicePrefix.LEH_S602S,
+] as const;
+
 export const NEW_FORMAT_PREFIXES = [
   DevicePrefix.OASIS_1000S,
   DevicePrefix.NeoClassic450S,
   DevicePrefix.LEH_S601S,
+  DevicePrefix.LEH_S602S,
   DevicePrefix.LV600S_V2,
 ] as const;
 
@@ -31,6 +40,9 @@ const matchesAnyPrefix = (
 
 export const isLV600S = (model: string): boolean =>
   matchesAnyPrefix(model, LV600S_PREFIXES);
+
+export const isSuperior6000S = (model: string): boolean =>
+  matchesAnyPrefix(model, SUPERIOR_6000S_PREFIXES);
 
 export const DeviceName = {
   Classic300S: 'Classic300S',
@@ -59,6 +71,7 @@ export const DeviceName = {
   NeoClassic450S_US: `${DevicePrefix.NeoClassic450S}WUS`,
   LEH_S601S_WUS: `${DevicePrefix.LEH_S601S}WUS`,
   LEH_S601S_WUSR: `${DevicePrefix.LEH_S601S}WUSR`,
+  LEH_S602S_WUS: `${DevicePrefix.LEH_S602S}WUS`,
   LUH_O601S_WUS: `${DevicePrefix.O601S}WUS`,
   LUH_O601S_KUS: `${DevicePrefix.O601S}KUS`,
 } as const;
@@ -198,11 +211,15 @@ const deviceTypes: DeviceType[] = [
     maxHumidityLevel: 80,
   },
   {
-    // LEH-S601S WUSR variants (lower min humidity)
+    // Superior 6000S WUSR variants (LEH-S601S-WUSR, lower min humidity)
     isValid: (input: string) =>
       input.includes(DevicePrefix.LEH_S601S) && input.includes('WUSR'),
     hasAutoMode: true,
     hasAutoProMode: true,
+    // Confirmed against pyvesync's device map: 'humidity' is a distinct workMode
+    // from 'autoPro' on this family, so the target humidity slider can safely
+    // target Humidity (Smart) mode instead of always forcing AutoPro. See #99.
+    humiditySliderTargetsAutoMode: true,
     mistLevels: 9,
     hasLight: false,
     hasColorMode: false,
@@ -212,10 +229,12 @@ const deviceTypes: DeviceType[] = [
     maxHumidityLevel: 80,
   },
   {
-    // LEH-S601S family (all other variants)
-    isValid: (input: string) => input.includes(DevicePrefix.LEH_S601S),
+    // Superior 6000S family (LEH-S601S-* and LEH-S602S-*, all other variants)
+    isValid: (input: string) => isSuperior6000S(input),
     hasAutoMode: true,
     hasAutoProMode: true,
+    // See comment above - confirmed via pyvesync's device map.
+    humiditySliderTargetsAutoMode: true,
     mistLevels: 9,
     hasLight: false,
     hasColorMode: false,

--- a/src/api/deviceTypes.ts
+++ b/src/api/deviceTypes.ts
@@ -80,6 +80,16 @@ export interface DeviceType {
   minHumidityLevel: number;
   maxHumidityLevel: number;
   hasAutoProMode?: boolean;
+  /**
+   * When true, dragging the primary target humidity slider targets Humidity (Smart) mode
+   * instead of AutoPro mode, leaving AutoPro reachable only via its dedicated switch.
+   *
+   * Opt-in and defaults to false/unset: on AutoPro-capable devices, VeSync's "humidity"
+   * workMode has only been confirmed for the LV600S family so far. Flip this to true for a
+   * given model only after confirming on real hardware that `workMode: "humidity"` is a
+   * valid mode for it (see #99) - until then it keeps today's behavior (slider -> AutoPro).
+   */
+  humiditySliderTargetsAutoMode?: boolean;
 }
 
 // All supported models, matched by either an exact model name or a stable device prefix.

--- a/src/characteristics/SleepState.ts
+++ b/src/characteristics/SleepState.ts
@@ -7,7 +7,7 @@ import {
 import { Mode } from '../api/VeSyncFan';
 
 import { AccessoryThisType } from '../VeSyncAccessory';
-import { DevicePrefix } from '../api/deviceTypes';
+import { isSuperior6000S } from '../api/deviceTypes';
 
 /**
  * SleepState characteristic handler for the Sleep Mode service.
@@ -42,7 +42,7 @@ const characteristic: {
   /**
    * Sets Sleep Mode state.
    * - On: Switches to Sleep Mode
-   * - Off: Switches to Auto Mode (or Humidity mode for LEH_S601S models)
+   * - Off: Switches to Auto Mode (or Humidity mode for Superior 6000S models)
    */
   set: async function (value: CharacteristicValue) {
     switch (value) {
@@ -53,8 +53,9 @@ const characteristic: {
         break;
       case false:
         // Turn off Sleep Mode - revert to appropriate auto mode
-        // LEH_S601S models have both Auto and Humidity modes, use Humidity since Auto has its own switch
-        if (this.device.model.includes(DevicePrefix.LEH_S601S)) {
+        // Superior 6000S models (LEH-S601S/LEH-S602S) have both Auto and Humidity
+        // modes, use Humidity since Auto has its own switch (AutoPro)
+        if (isSuperior6000S(this.device.model)) {
           await this.device.changeMode(Mode.Humidity);
           this.updateAllCharacteristics();
           break;

--- a/src/characteristics/TargetHumidity.ts
+++ b/src/characteristics/TargetHumidity.ts
@@ -7,7 +7,7 @@ import {
 
 import { AccessoryThisType } from '../VeSyncAccessory';
 import { Mode } from '../api/VeSyncFan';
-import { DevicePrefix, isLV600S } from '../api/deviceTypes';
+import { DevicePrefix, isLV600S, isNewFormatDevice } from '../api/deviceTypes';
 import { debounceSet } from '../utils/debounce';
 
 /**
@@ -72,11 +72,13 @@ const characteristic: {
             h = device.deviceType.maxHumidityLevel;
 
           // Determine correct auto-like mode based on device type
-          // LV600S uses "Humidity" mode; AutoPro-capable devices use "Humidity" mode too
-          // once verified (see humiditySliderTargetsAutoMode), otherwise "AutoPro"; others use "Auto"
+          // Only the newer LUH-A603S uses "Humidity" mode (the older LUH-A602S uses
+          // plain "Auto" - confirmed against pyvesync's device map). AutoPro-capable
+          // devices use "Humidity" mode too once verified (see
+          // humiditySliderTargetsAutoMode), otherwise "AutoPro"; others use "Auto"
           let autoLikeMode: Mode;
           if (
-            isLV600S(device.model) ||
+            (isLV600S(device.model) && isNewFormatDevice(device.model)) ||
             (device.deviceType.hasAutoProMode &&
               device.deviceType.humiditySliderTargetsAutoMode)
           ) {

--- a/src/characteristics/TargetHumidity.ts
+++ b/src/characteristics/TargetHumidity.ts
@@ -72,9 +72,14 @@ const characteristic: {
             h = device.deviceType.maxHumidityLevel;
 
           // Determine correct auto-like mode based on device type
-          // LV600S uses "Humidity" mode, others use "Auto" or "AutoPro"
+          // LV600S uses "Humidity" mode; AutoPro-capable devices use "Humidity" mode too
+          // once verified (see humiditySliderTargetsAutoMode), otherwise "AutoPro"; others use "Auto"
           let autoLikeMode: Mode;
-          if (isLV600S(device.model)) {
+          if (
+            isLV600S(device.model) ||
+            (device.deviceType.hasAutoProMode &&
+              device.deviceType.humiditySliderTargetsAutoMode)
+          ) {
             autoLikeMode = Mode.Humidity;
           } else if (device.deviceType.hasAutoProMode) {
             autoLikeMode = Mode.AutoPro;

--- a/src/characteristics/TargetHumidity.ts
+++ b/src/characteristics/TargetHumidity.ts
@@ -27,12 +27,14 @@ const characteristic: {
 } & AccessoryThisType = {
   /**
    * Gets the current target humidity percentage.
-   * Returns 0 if the device is off.
+   * Returns the last known target even when the device is off, so the Home app
+   * shows the correct value immediately instead of flashing 0% on power on.
+   * HomeKit already grays out the slider based on the Active characteristic.
    * Uses cached state to ensure fast response times.
    */
   get: async function (): Promise<Nullable<CharacteristicValue>> {
     // Use cached state - background polling keeps this fresh
-    return this.device.isOn ? this.device.targetHumidity : 0;
+    return this.device.targetHumidity;
   },
 
   /**

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -28,9 +28,8 @@ export type VeSyncPlatformAccessory = PlatformAccessory<VeSyncContext>;
  * Handles device discovery, accessory registration, and lifecycle management.
  */
 export default class Platform implements DynamicPlatformPlugin {
-  public readonly Service: typeof Service = this.api.hap.Service;
-  public readonly Characteristic: typeof Characteristic =
-    this.api.hap.Characteristic;
+  public readonly Service: typeof Service;
+  public readonly Characteristic: typeof Characteristic;
 
   /** Cached accessories loaded from Homebridge's persistent storage */
   public readonly cachedAccessories: VeSyncPlatformAccessory[] = [];
@@ -46,6 +45,12 @@ export default class Platform implements DynamicPlatformPlugin {
     public readonly config: PlatformConfig,
     public readonly api: API,
   ) {
+    // Assigned in the constructor body (not as field initializers) since
+    // field initializers run before parameter properties like `api` are
+    // assigned under native ES2022 class field semantics.
+    this.Service = this.api.hap.Service;
+    this.Characteristic = this.api.hap.Characteristic;
+
     const { email, password } = this.config ?? {};
     // Support backwards compatibility: check top-level first, then options
     const enableDebugMode =

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/"],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2018", // ~node10
+    "target": "ES2022", // matches engines.node >=20.19.0
     "module": "commonjs",
-    "lib": ["es2015", "es2016", "es2017", "es2018", "es2021"],
+    "lib": ["es2022"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -10,7 +10,6 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "noImplicitAny": false,
     "skipLibCheck": true
   },
   "include": ["src/"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,6 +389,13 @@ acorn@^8.4.1, acorn@^8.9.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
@@ -512,6 +519,11 @@ async-lock@^1.3.0:
   resolved "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz"
   integrity sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz"
@@ -519,12 +531,15 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz"
-  integrity sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==
+axios@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.18.1.tgz#d63f9863bcd8938815c86f9e2abd380189d96dfe"
+  integrity sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==
   dependencies:
-    follow-redirects "^1.14.4"
+    follow-redirects "^1.16.0"
+    form-data "^4.0.5"
+    https-proxy-agent "^5.0.1"
+    proxy-from-env "^2.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -644,6 +659,13 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@14.0.2:
   version "14.0.2"
   resolved "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz"
@@ -695,19 +717,19 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+debug@4, debug@^4.3.1, debug@^4.3.2, debug@^4.4.1, debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.3.1, debug@^4.3.2, debug@^4.4.1, debug@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
-  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
-  dependencies:
-    ms "^2.1.3"
 
 deep-equal@^2.2.3:
   version "2.2.3"
@@ -755,6 +777,11 @@ define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -1159,10 +1186,10 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
-follow-redirects@^1.14.4:
-  version "1.15.5"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz"
-  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.3, for-each@^0.3.5:
   version "0.3.5"
@@ -1170,6 +1197,17 @@ for-each@^0.3.3, for-each@^0.3.5:
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
+
+form-data@^4.0.5:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 from@^0.1.7:
   version "0.1.7"
@@ -1364,6 +1402,13 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
+
 hexy@^0.3.5:
   version "0.3.5"
   resolved "https://registry.npmjs.org/hexy/-/hexy-0.3.5.tgz"
@@ -1382,6 +1427,14 @@ homebridge@^2.0.0-beta.68:
     qrcode-terminal "0.12.0"
     semver "7.7.3"
     source-map-support "0.5.21"
+
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 ignore-by-default@^1.0.1:
   version "1.0.1"
@@ -1731,6 +1784,18 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
@@ -1982,6 +2047,11 @@ prettier@^3.1.1:
   version "3.2.2"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.2.2.tgz"
   integrity sha512-HTByuKZzw7utPiDO523Tt2pLtEyK7OibUD9suEJQrPUCYQqrHr74GGX6VidMrovbf/I50mPqr8j/II6oBAuc5A==
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 pstree.remy@^1.1.8:
   version "1.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,6 +268,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-16.18.71.tgz"
   integrity sha512-ARO+458bNJQeNEFuPyT6W+q9ULotmsQzhV3XABsFSxEvRMUYENcBsNAHWYPlahU+UHa5gCVwyKT1Z3f1Wwr26Q==
 
+"@types/uuid@^9.0.8":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
+
 "@typescript-eslint/eslint-plugin@^8.52.0":
   version "8.52.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.52.0.tgz"


### PR DESCRIPTION
## Summary

Targets **v1.22.0-beta.2** (published) - includes everything below.

**Bug fixes:**
- Fixes #104: warm mist wasn't syncing on new-format devices (e.g. LUH-A603S). Two separate bugs, both confirmed against [pyvesync](https://github.com/webdjoe/pyvesync)'s device map/LV600S class:
  - The *set* command used the wrong payload shape (needed `{levelIdx, levelType: 'warm', mistLevel: 0, warmLevel}` via `setLevel`, not a `virtualLevel`-style command like cool mist).
  - Background polling was reading warm mist state from the wrong JSON keys for new-format devices (snake_case `warm_level`/`warm_enabled` instead of the camelCase `warmLevel`/`warmPower` these devices actually return), so state was silently reset to off on every poll regardless of the device's real state.
- Fixes #102: target humidity flashed 0% on power-on. `TargetHumidity.get()` forced 0% whenever the device was off, and `setPower(false)` zeroed the retained value out from under it. Target humidity is now retained across power-off and returned as-is; HomeKit already grays out the slider via `Active`.
- Fixed an LV600S mode-string bug (`changeMode()` and `TargetHumidity.ts`): only the newer LUH-A603S uses `'humidity'` as its Auto-equivalent `workMode` — the older LUH-A602S uses plain `'auto'`. Both were incorrectly forcing `'humidity'` onto A602S too, confirmed against pyvesync's device map.
- Fixed `SleepState.ts` missing `LEH-S602S-WUS` in its Superior 6000S check — turning off Sleep Mode on that device incorrectly engaged AutoPro instead of Humidity mode.

**Features:**
- Fixes #106: adds `options.pollingInterval` config (seconds, 10s minimum, default 30s) so users sharing their VeSync API quota with another integration can reduce polling frequency.
- Addresses #99: enabled `humiditySliderTargetsAutoMode` for Superior 6000S devices, backed by pyvesync's device map confirming `'humidity'` is a distinct `workMode` from `'autoPro'` on `LEH-S601S-*`/`LEH-S602S-*`. The target humidity slider now targets Humidity (Smart) mode instead of always forcing AutoPro.
- Adds `LEH-S602S-WUS` device support. A commit adding this (`f67e04b`) only ever lived on the old `99-superior-6000s-enhancements` branch and never landed in `main`'s history, so real S602S hardware wasn't recognized at all. Grouped under a new `isSuperior6000S()` helper alongside `LEH-S601S`.

**Repo hygiene / infra:**
- Added NeoClassic 450S to the README's supported-devices table (shipped in #110, table was never updated).
- Upgraded `axios` `0.24.0` → `1.18.1` (predates several security fixes; usage is stable API surface, no code changes needed).
- Fixed `codeql-analysis.yml` triggering on branch `master`, which doesn't exist (default branch is `main`) — push/PR scans were silently only running on the weekly cron.
- Fixed `yarn lint` silently skipping ~75% of `src/` (everything under `api/`, `characteristics/`, `utils/`) due to a non-recursive glob (`src/**.ts` instead of `src/**/*.ts`) — only one latent formatting issue surfaced once corrected.
- Enabled `noImplicitAny` and bumped the TS build target ES2018 → ES2022 (matching `engines.node >=20.19.0`). Fixing the resulting errors caught a real latent bug: `platform.ts` assigned `Service`/`Characteristic` as class field initializers reading `this.api`, which only worked under the old target's legacy class-field emit order — this would have been a startup crash under native ES2022 class fields had the target changed without the fix.
- Extracted the repeated `isNewFormatDevice(this.model) ? {...} : {...}` payload-branching pattern (6 call sites) into a single `formatPayload()` helper.
- Added a unit test suite (`node:test`, no new dependency) covering `VeSyncFan`'s command-building logic — the exact payload shape/method per device generation for every set-command, plus `updateInfo()`'s read-side field mapping. This is the area most prone to silent regressions, exactly as demonstrated by the #104 saga above (including my own first, wrong fix attempt). Wired into CI and `prepublishOnly`.
- Deleted 26 stale remote branches (21 already merged, 5 investigated and confirmed to be abandoned/superseded WIP with nothing left to recover).
- Removed a duplicate keyword in `package.json`; updated `CHANGELOG.md` (stale since 1.15.0).

## Test plan
- [x] `yarn build` / `yarn lint` / `yarn test` — all clean
- [x] Verified the new test suite actually catches regressions (reintroduced the original #104 bug locally, confirmed a test fails, reverted)
- [ ] Manual verification against real LUH-A602S and LUH-A603S hardware for mode strings and warm mist sync
- [ ] Manual verification in Home app that target humidity no longer flashes 0% on power-on
- [ ] Manual verification of Superior 6000S / LEH-S602S-WUS humidity slider and sleep-mode-off reaching Humidity (Smart) mode instead of AutoPro
- [ ] Manual verification of LEH-S602S-WUS device discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)