### PR TITLE
Fix AutoPro-off returning to Manual instead of Humidity (Smart) mode

### DIFF
--- a/src/characteristics/AutoProState.ts
+++ b/src/characteristics/AutoProState.ts
@@ -10,14 +10,15 @@ import { AccessoryThisType } from '../VeSyncAccessory';
 
 /**
  * AutoProState characteristic handler for the AutoPro Mode service.
- * Controls whether the device is in AutoPro Mode or Manual Mode.
+ * Controls whether the device is in AutoPro Mode or returns to Humidity (Smart) mode.
  *
  * AutoPro Mode is available on certain models (e.g., Superior 6000S) and provides
  * advanced automatic humidity control.
  *
  * Behavior:
  * - On: Switches to AutoPro Mode
- * - Off: Switches to Manual Mode
+ * - Off: Returns to Humidity (Smart) mode on devices where that's confirmed valid
+ *   (see humiditySliderTargetsAutoMode), otherwise falls back to Manual mode
  * - Returns false if device is off (so switch displays Off)
  *
  * Note: Uses cached device state from background polling to avoid slow read warnings.
@@ -44,7 +45,7 @@ const characteristic: {
   /**
    * Sets AutoPro Mode state.
    * - On: Switches to AutoPro Mode
-   * - Off: Switches to Manual Mode
+   * - Off: Returns to Humidity (Smart) mode where verified, otherwise Manual
    */
   set: async function (value: CharacteristicValue) {
     switch (value) {
@@ -54,8 +55,14 @@ const characteristic: {
         this.updateAllCharacteristics();
         break;
       case false:
-        // Turn off AutoPro Mode - switch to Manual
-        await this.device.changeMode(Mode.Manual);
+        // Turn off AutoPro Mode - return to Humidity (Smart) mode on devices
+        // where that's confirmed valid, otherwise fall back to Manual (matches
+        // the target humidity slider's mode selection in TargetHumidity.ts)
+        await this.device.changeMode(
+          this.device.deviceType.humiditySliderTargetsAutoMode
+            ? Mode.Humidity
+            : Mode.Manual,
+        );
         this.updateAllCharacteristics();
         break;
     }


### PR DESCRIPTION
## Summary
Completes #99. Re-checking the shipped v1.22.0 fix for #99 against the mode-mapping table from #102 found one remaining gap: `AutoProState.ts` still sent `Manual` mode when the AutoPro switch was turned off, contradicting the documented mapping (AutoPro off → Humidity/Smart mode). This was missed because that file wasn't touched by the earlier #99 work — only `TargetHumidity.ts` and `SleepState.ts` were.

Now gated behind `humiditySliderTargetsAutoMode` (same flag as the other two fixes), so it only changes behavior for devices confirmed to support Humidity mode (currently Superior 6000S / `LEH-S601S-*` / `LEH-S602S-*`) and falls back to the previous Manual behavior for any other AutoPro-capable device.

## Test plan
- [x] `yarn build` / `yarn lint` / `yarn test` — all clean
- [ ] Manual verification on Superior 6000S hardware: turn AutoPro on then off via HomeKit, confirm device returns to Humidity/Smart mode (not Manual/Fan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)