### PR TITLE
Add Sprout Humidifier (LEH-B381S-*) device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a Homebridge plugin to control Levoit Humidifiers from Apple HomeKit.
 | Supported Versions | Auto / Humidity | Mist | Sleep | Light | Display | Warm |
 | ------------------ | --------------- | ---- | ----- | ----- | ------- | ---- |
 | Superior 6000S     | ✅              | ✅   | ✅    | ❌    | ✅      | ❌   |
+| Sprout Humidifier  | ✅              | ✅   | ✅    | ❌    | ✅      | ❌   |
 | OasisMist 1000S    | ✅              | ✅   | ✅    | ❌    | ✅      | ❌   |
 | OasisMist 600S     | ✅              | ✅   | ✅    | ❌    | ✅      | ✅   |
 | OasisMist 450S     | ✅              | ✅   | ✅    | ❌    | ✅      | ✅   |

--- a/src/api/VeSyncFan.spec.ts
+++ b/src/api/VeSyncFan.spec.ts
@@ -115,6 +115,7 @@ const LV600S_OLD = 'LUH-A602S-WUS'; // old format, has warm mist
 const LV600S_NEW = 'LUH-A603S-WUS'; // new format, has warm mist
 const SUPERIOR_6000S = 'LEH-S601S-WUS'; // new format, AutoPro, no warm mist
 const NEOCLASSIC_450S = 'LUH-N451S-WUS'; // new format, no warm mist
+const SPROUT = 'LEH-B381S-WUS'; // new format, AutoPro-only (no separate Humidity mode)
 
 describe('VeSyncFan.setPower', () => {
   it('sends the old-format payload for pre-A603S devices', async () => {
@@ -226,6 +227,17 @@ describe('VeSyncFan.changeMode', () => {
     assert.equal(fan.mode, Mode.AutoPro);
   });
 
+  it('remaps Auto to AutoPro for Sprout, which has no separate Humidity mode', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, SPROUT, { mode: Mode.Manual });
+
+    await fan.changeMode(Mode.Auto);
+
+    assert.deepEqual(calls[0].body, { workMode: 'autoPro' });
+    assert.equal(fan.mode, Mode.AutoPro);
+  });
+
   it('skips the API call when already in the requested mode', async () => {
     const client = createClient();
     const { calls } = stubSendCommand(client);
@@ -256,6 +268,18 @@ describe('VeSyncFan.changeMistLevel', () => {
     const fan = createFan(client, CLASSIC_300S);
 
     assert.equal(await fan.changeMistLevel(0), false);
+  });
+
+  it('respects a device-specific lower max (Sprout only has 2 mist levels)', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, SPROUT);
+
+    assert.equal(await fan.changeMistLevel(3), false);
+    assert.equal(calls.length, 0);
+
+    await fan.changeMistLevel(2);
+    assert.equal(calls.length, 1);
   });
 
   it('sends the old-format payload', async () => {

--- a/src/api/deviceTypes.ts
+++ b/src/api/deviceTypes.ts
@@ -11,6 +11,7 @@ export enum DevicePrefix {
   LEH_S601S = 'LEH-S601S-',
   LEH_S602S = 'LEH-S602S-',
   O601S = 'LUH-O601S-',
+  Sprout = 'LEH-B381S-',
 }
 
 export const LV600S_PREFIXES = [
@@ -31,6 +32,7 @@ export const NEW_FORMAT_PREFIXES = [
   DevicePrefix.LEH_S601S,
   DevicePrefix.LEH_S602S,
   DevicePrefix.LV600S_V2,
+  DevicePrefix.Sprout,
 ] as const;
 
 const matchesAnyPrefix = (
@@ -74,6 +76,8 @@ export const DeviceName = {
   LEH_S602S_WUS: `${DevicePrefix.LEH_S602S}WUS`,
   LUH_O601S_WUS: `${DevicePrefix.O601S}WUS`,
   LUH_O601S_KUS: `${DevicePrefix.O601S}KUS`,
+  Sprout_WUS: `${DevicePrefix.Sprout}WUS`,
+  Sprout_WEU: `${DevicePrefix.Sprout}WEU`,
 } as const;
 
 export type DeviceName = (typeof DeviceName)[keyof typeof DeviceName];
@@ -255,6 +259,27 @@ const deviceTypes: DeviceType[] = [
     hasWarmMode: true,
     warmMistLevels: 3,
     minHumidityLevel: 40,
+    maxHumidityLevel: 80,
+  },
+  {
+    // Sprout Humidifier family (LEH-B381S-*). Per pyvesync's device map, this
+    // device's only auto-like mode is "autoPro" (no separate "humidity" mode
+    // like Superior 6000S has), so humiditySliderTargetsAutoMode is left unset
+    // and the target humidity slider/AutoPro-off correctly fall back to
+    // AutoPro/Manual. It also has a tunable-white night light (brightness +
+    // color temperature, not RGB), drying mode, child lock, and filter/
+    // temperature sensors - none of which this plugin models yet for any
+    // device, so hasLight stays false here rather than exposing a control
+    // shape we don't actually support.
+    isValid: (input: string) => input.includes(DevicePrefix.Sprout),
+    hasAutoMode: true,
+    hasAutoProMode: true,
+    mistLevels: 2,
+    hasLight: false,
+    hasColorMode: false,
+    hasSleepMode: true,
+    hasWarmMode: false,
+    minHumidityLevel: 30,
     maxHumidityLevel: 80,
   },
 ];


### PR DESCRIPTION
## Summary
While comparing our supported models against [pyvesync](https://github.com/webdjoe/pyvesync)'s device map (asked: "am I missing any models?"), found the **Sprout Humidifier** (`LEH-B381S-WUS`/`LEH-B381S-WEU`) is a real, distinct VeSync product line that this plugin doesn't recognize at all - a user with one would silently fail device discovery (caught by the try/catch in `platform.ts`, logged, no HomeKit accessory, no visible error to them).

Added support scoped to what our existing feature set handles cleanly, using the existing new-format command paths with no special-casing:
- Power, mode (AutoPro / Sleep / Manual), 2 mist levels (this device only has 2, not 9), target humidity, display.
- `hasLight: false` - Sprout has a tunable-white night light (brightness + color temperature) that doesn't match either of our two existing light-control shapes (plain brightness vs full RGB). Also skipped drying mode, child lock, and filter/temperature sensors, none of which this plugin models for any device.
- No `humiditySliderTargetsAutoMode` - unlike Superior 6000S, pyvesync shows Sprout has no separate `"humidity"` workMode, only `"autoPro"`, so the target humidity slider and AutoPro-off correctly fall back to AutoPro/Manual (verified by test).

**Deliberately did not** add the Oasis 450S EU RGB night light gap I'd also flagged - pyvesync has an open, unresolved issue ([webdjoe/pyvesync#500](https://github.com/webdjoe/pyvesync/issues/500)) where the maintainer's own `LUH-O451S-WUSR` unit has no night light, contradicting a user's screenshots of the same model number. That feature data is actively disputed upstream, not something to build a fix on.

## Test plan
- [x] `yarn build` / `yarn lint` / `yarn test` — all clean, added 2 new tests for Sprout's AutoPro-only mode fallback and its 2-level mist max
- [ ] Manual verification against real Sprout hardware (I don't have access) - would appreciate anyone with one testing before wide release

🤖 Generated with [Claude Code](https://claude.com/claude-code)