### PR TITLE
Bump version to 1.22.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.22.1",
+  "version": "1.22.2",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"


### PR DESCRIPTION
## Summary
Version bump to 1.22.2 to cover the AutoPro-off fix (#112) and Sprout Humidifier support that landed on main since the 1.22.1 release.

## Test plan
- [x] `yarn build` / `yarn lint` / `yarn test` — all clean