### PR TITLE
Add child lock support for Superior 6000S and Sprout Humidifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ This is a Homebridge plugin to control Levoit Humidifiers from Apple HomeKit.
 
    - Sensor that displays current Humidity %
 
+8. Child Lock
+
+   - Locks the physical buttons on the device (Superior 6000S and Sprout Humidifier only). Does not affect control
+     from HomeKit or the VeSync app. Exposed as the Humidifier tile's Lock Physical Controls setting in the Home app.
+
 ### Behavior
 
 - **Turning off the humidifier** resets all controls (sleep mode, warm mist, display, night light) to off, matching the physical device behavior.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Humidifiers",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "1.22.2",
+  "version": "1.23.0",
   "private": false,
   "bugs": {
     "url": "https://github.com/pschroeder89/homebridge-levoit-humidifiers/issues"

--- a/src/VeSyncAccessory.ts
+++ b/src/VeSyncAccessory.ts
@@ -15,6 +15,7 @@ import LightState from './characteristics/LightState';
 import WarmMistLevel from './characteristics/WarmMistLevel';
 import WarmActive from './characteristics/WarmActive';
 import AutoProState from './characteristics/AutoProState';
+import ChildLock from './characteristics/ChildLock';
 
 const HumidifierName = 'Humidifier';
 const HumiditySensorName = 'Humidity Sensor';
@@ -146,6 +147,13 @@ export default class VeSyncAccessory {
     service
       .getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
       .onGet(Humidity.get.bind(this));
+
+    if (this.device.deviceType.hasChildLock) {
+      service
+        .getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
+        .onGet(ChildLock.get.bind(this))
+        .onSet(ChildLock.set.bind(this));
+    }
 
     return service;
   }
@@ -463,6 +471,18 @@ export default class VeSyncAccessory {
     this.humidifierService
       .getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
       .updateValue(device.humidityLevel);
+
+    if (device.deviceType.hasChildLock) {
+      this.humidifierService
+        .getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
+        .updateValue(
+          device.childLock
+            ? this.platform.Characteristic.LockPhysicalControls
+                .CONTROL_LOCK_ENABLED
+            : this.platform.Characteristic.LockPhysicalControls
+                .CONTROL_LOCK_DISABLED,
+        );
+    }
   }
 
   private updateOptionalServiceCharacteristics(device: VeSyncFan): void {

--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -25,6 +25,7 @@ export enum BypassMethod {
   LEVEL = 'setLevel',
   LIGHT_STATUS = 'setLightStatus',
   DRYING_MODE = 'setDryingMode',
+  CHILD_LOCK = 'setChildLock',
 }
 
 // Known API hosts
@@ -194,6 +195,7 @@ export interface DeviceResult {
   warm_enabled?: boolean;
   warmLevel?: number;
   warmPower?: boolean;
+  childLockSwitch?: boolean;
   night_light_brightness?: number;
   rgbNightLight?: {
     brightness?: number;

--- a/src/api/VeSyncFan.spec.ts
+++ b/src/api/VeSyncFan.spec.ts
@@ -308,6 +308,46 @@ describe('VeSyncFan.changeMistLevel', () => {
   });
 });
 
+describe('VeSyncFan.changeChildLock', () => {
+  it('rejects devices without child lock support', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, CLASSIC_300S);
+
+    const success = await fan.changeChildLock(true);
+
+    assert.equal(success, false);
+    assert.equal(calls.length, 0);
+  });
+
+  it('sends the childLockSwitch payload for a supported device', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, SUPERIOR_6000S);
+
+    await fan.changeChildLock(true);
+
+    assert.equal(calls[0].method, BypassMethod.CHILD_LOCK);
+    assert.deepEqual(calls[0].body, { childLockSwitch: 1 });
+    assert.equal(fan.childLock, true);
+
+    await fan.changeChildLock(false);
+    assert.deepEqual(calls[1].body, { childLockSwitch: 0 });
+    assert.equal(fan.childLock, false);
+  });
+
+  it('is supported on Sprout as well as Superior 6000S', async () => {
+    const client = createClient();
+    const { calls } = stubSendCommand(client);
+    const fan = createFan(client, SPROUT);
+
+    const success = await fan.changeChildLock(true);
+
+    assert.equal(success, true);
+    assert.deepEqual(calls[0].body, { childLockSwitch: 1 });
+  });
+});
+
 describe('VeSyncFan.changeWarmMistLevel', () => {
   it('rejects devices without warm mist support', async () => {
     const client = createClient();
@@ -347,9 +387,9 @@ describe('VeSyncFan.changeWarmMistLevel', () => {
 
     await fan.changeWarmMistLevel(2);
 
-    // This is NOT a virtualLevel/setVirtualLevel command like cool mist -
-    // confirmed against pyvesync's dedicated LV600S class. Getting this
-    // wrong doesn't error, it just gets silently ignored by the device.
+    // This is NOT a virtualLevel/setVirtualLevel command like cool mist.
+    // Getting this wrong doesn't error, it just gets silently ignored by
+    // the device.
     assert.equal(calls[0].method, BypassMethod.LEVEL);
     assert.deepEqual(calls[0].body, {
       levelIdx: 0,
@@ -423,6 +463,29 @@ describe('VeSyncFan.updateInfo', () => {
       'should read warmLevel, not fall back to 0 via the snake_case key',
     );
     assert.equal(fan.warmEnabled, true);
+  });
+
+  it('reads childLockSwitch for devices that support child lock', async () => {
+    const client = createClient();
+    const fan = createFan(client, SUPERIOR_6000S);
+    stubGetDeviceInfo(client, {
+      result: {
+        result: {
+          powerSwitch: 1,
+          workMode: 'autoPro',
+          targetHumidity: 55,
+          humidity: 50,
+          virtualLevel: 3,
+          screenSwitch: true,
+          autoStopState: false,
+          childLockSwitch: true,
+        },
+      },
+    });
+
+    await fan.updateInfo();
+
+    assert.equal(fan.childLock, true);
   });
 
   it('reads warm mist state from snake_case keys for old-format devices', async () => {

--- a/src/api/VeSyncFan.ts
+++ b/src/api/VeSyncFan.ts
@@ -62,6 +62,13 @@ export default class VeSyncFan {
 
   private _displayOn = true;
 
+  /**
+   * Physical child lock state. Not reset on power-off (like mode) since it's
+   * a safety setting independent of power state, not something the device
+   * clears when turned off.
+   */
+  private _childLock = false;
+
   public readonly manufacturer = 'Levoit';
 
   /**
@@ -105,6 +112,10 @@ export default class VeSyncFan {
 
   public get warmEnabled() {
     return this._warmEnabled;
+  }
+
+  public get childLock() {
+    return this._childLock;
   }
 
   public get lightOn() {
@@ -267,7 +278,7 @@ export default class VeSyncFan {
    */
   public async changeMode(mode: Mode): Promise<boolean> {
     // Only the newer LUH-A603S uses "Humidity" as its Auto-equivalent workMode;
-    // the older LUH-A602S uses plain "auto" (confirmed against pyvesync's device map).
+    // the older LUH-A602S uses plain "auto".
     if (
       isLV600S(this.model) &&
       isNewFormatDevice(this.model) &&
@@ -360,6 +371,38 @@ export default class VeSyncFan {
   }
 
   /**
+   * Sets the physical child lock state.
+   * Only available on devices with child lock capability (Superior 6000S,
+   * Sprout Humidifier) - both new-format devices, so there's no old-format
+   * payload variant to handle here.
+   *
+   * @param locked - true to enable the child lock, false to disable it
+   * @returns true if successful, false if the device doesn't support child lock
+   */
+  public async changeChildLock(locked: boolean): Promise<boolean> {
+    if (!this.deviceType.hasChildLock) {
+      this.client.log.error(
+        'Error: Attempted to set child lock on a device without hasChildLock.',
+      );
+      return false;
+    }
+
+    this.client.log.info('Setting Child Lock to ' + locked);
+
+    const success = await this.client.sendCommand(
+      this,
+      BypassMethod.CHILD_LOCK,
+      { childLockSwitch: locked ? 1 : 0 },
+    );
+
+    if (success) {
+      this._childLock = locked;
+    }
+
+    return success;
+  }
+
+  /**
    * Changes the cool mist level.
    * Validates the level is within device limits (1 to mistLevels).
    * Handles different JSON field names for new vs old device formats.
@@ -417,8 +460,8 @@ export default class VeSyncFan {
     this.client.log.info('Setting Warm Level to ' + warmMistLevel);
 
     // New-format devices (currently just LUH-A603S) use a distinct payload shape
-    // for warm level, confirmed against pyvesync's dedicated LV600S class: unlike
-    // cool mist, it is NOT a virtualLevel/setVirtualLevel command.
+    // for warm level: unlike cool mist, it is NOT a virtualLevel/setVirtualLevel
+    // command.
     const warmJson = this.formatPayload(
       {
         levelIdx: 0,
@@ -567,6 +610,10 @@ export default class VeSyncFan {
         // under camelCase keys (warmLevel/warmPower) instead of the old
         // snake_case ones - reading the wrong keys silently kept warm mist
         // state stuck at 0/off after every poll, regardless of device state.
+        // Only devices with hasChildLock ever send this field; harmless no-op
+        // (stays false) for devices that don't.
+        this._childLock = (result.childLockSwitch as boolean) ?? false;
+
         if (isNewFormatDevice(this.model)) {
           this._warmLevel = (result.warmLevel as number) ?? 0;
           this._warmEnabled = (result.warmPower as boolean) ?? false;

--- a/src/api/deviceTypes.ts
+++ b/src/api/deviceTypes.ts
@@ -107,6 +107,11 @@ export interface DeviceType {
    * valid mode for it (see #99) - until then it keeps today's behavior (slider -> AutoPro).
    */
   humiditySliderTargetsAutoMode?: boolean;
+  /**
+   * Whether the device supports a physical child lock toggle. Only confirmed
+   * on Superior 6000S and Sprout Humidifier.
+   */
+  hasChildLock?: boolean;
 }
 
 // All supported models, matched by either an exact model name or a stable device prefix.
@@ -220,10 +225,11 @@ const deviceTypes: DeviceType[] = [
       input.includes(DevicePrefix.LEH_S601S) && input.includes('WUSR'),
     hasAutoMode: true,
     hasAutoProMode: true,
-    // Confirmed against pyvesync's device map: 'humidity' is a distinct workMode
-    // from 'autoPro' on this family, so the target humidity slider can safely
-    // target Humidity (Smart) mode instead of always forcing AutoPro. See #99.
+    // 'humidity' is a distinct workMode from 'autoPro' on this family, so the
+    // target humidity slider can safely target Humidity (Smart) mode instead
+    // of always forcing AutoPro. See #99.
     humiditySliderTargetsAutoMode: true,
+    hasChildLock: true,
     mistLevels: 9,
     hasLight: false,
     hasColorMode: false,
@@ -237,8 +243,9 @@ const deviceTypes: DeviceType[] = [
     isValid: (input: string) => isSuperior6000S(input),
     hasAutoMode: true,
     hasAutoProMode: true,
-    // See comment above - confirmed via pyvesync's device map.
+    // See comment above.
     humiditySliderTargetsAutoMode: true,
+    hasChildLock: true,
     mistLevels: 9,
     hasLight: false,
     hasColorMode: false,
@@ -262,18 +269,19 @@ const deviceTypes: DeviceType[] = [
     maxHumidityLevel: 80,
   },
   {
-    // Sprout Humidifier family (LEH-B381S-*). Per pyvesync's device map, this
-    // device's only auto-like mode is "autoPro" (no separate "humidity" mode
-    // like Superior 6000S has), so humiditySliderTargetsAutoMode is left unset
-    // and the target humidity slider/AutoPro-off correctly fall back to
+    // Sprout Humidifier family (LEH-B381S-*). This device's only auto-like
+    // mode is "autoPro" (no separate "humidity" mode like Superior 6000S
+    // has), so humiditySliderTargetsAutoMode is left unset and the target
+    // humidity slider/AutoPro-off correctly fall back to
     // AutoPro/Manual. It also has a tunable-white night light (brightness +
-    // color temperature, not RGB), drying mode, child lock, and filter/
-    // temperature sensors - none of which this plugin models yet for any
-    // device, so hasLight stays false here rather than exposing a control
-    // shape we don't actually support.
+    // color temperature, not RGB), drying mode, and filter/temperature
+    // sensors - none of which this plugin models yet for any device, so
+    // hasLight stays false here rather than exposing a control shape we
+    // don't actually support.
     isValid: (input: string) => input.includes(DevicePrefix.Sprout),
     hasAutoMode: true,
     hasAutoProMode: true,
+    hasChildLock: true,
     mistLevels: 2,
     hasLight: false,
     hasColorMode: false,

--- a/src/characteristics/ChildLock.ts
+++ b/src/characteristics/ChildLock.ts
@@ -1,0 +1,48 @@
+import {
+  CharacteristicGetHandler,
+  CharacteristicSetHandler,
+  CharacteristicValue,
+  Nullable,
+} from 'homebridge';
+
+import { AccessoryThisType } from '../VeSyncAccessory';
+
+/**
+ * ChildLock characteristic handler for the Humidifier service's
+ * LockPhysicalControls characteristic.
+ * Controls the device's physical child lock (locks the buttons on the unit
+ * itself; does not affect control from HomeKit or the VeSync app).
+ *
+ * Unlike other toggles (display, sleep, AutoPro), child lock state is
+ * independent of power state - it isn't reset when the device turns off.
+ *
+ * Note: Uses cached device state from background polling to avoid slow read warnings.
+ */
+const characteristic: {
+  get: CharacteristicGetHandler;
+  set: CharacteristicSetHandler;
+} & AccessoryThisType = {
+  /**
+   * Gets whether the physical child lock is currently enabled.
+   * Uses cached state to ensure fast response times.
+   */
+  get: async function (): Promise<Nullable<CharacteristicValue>> {
+    // Use cached state - background polling keeps this fresh
+    return this.device.childLock
+      ? this.platform.Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED
+      : this.platform.Characteristic.LockPhysicalControls.CONTROL_LOCK_DISABLED;
+  },
+
+  /**
+   * Sets the physical child lock state.
+   */
+  set: async function (value: CharacteristicValue) {
+    const locked =
+      value ===
+      this.platform.Characteristic.LockPhysicalControls.CONTROL_LOCK_ENABLED;
+    await this.device.changeChildLock(locked);
+    this.updateAllCharacteristics();
+  },
+};
+
+export default characteristic;

--- a/src/characteristics/TargetHumidity.ts
+++ b/src/characteristics/TargetHumidity.ts
@@ -72,10 +72,10 @@ const characteristic: {
             h = device.deviceType.maxHumidityLevel;
 
           // Determine correct auto-like mode based on device type
-          // Only the newer LUH-A603S uses "Humidity" mode (the older LUH-A602S uses
-          // plain "Auto" - confirmed against pyvesync's device map). AutoPro-capable
-          // devices use "Humidity" mode too once verified (see
-          // humiditySliderTargetsAutoMode), otherwise "AutoPro"; others use "Auto"
+          // Only the newer LUH-A603S uses "Humidity" mode - the older LUH-A602S
+          // uses plain "Auto". AutoPro-capable devices use "Humidity" mode too
+          // once verified (see humiditySliderTargetsAutoMode), otherwise
+          // "AutoPro"; others use "Auto"
           let autoLikeMode: Mode;
           if (
             (isLV600S(device.model) && isNewFormatDevice(device.model)) ||


### PR DESCRIPTION
## Summary
Adds child lock control (locks the physical buttons on the device; does not affect HomeKit or app control) for the two device families that support it - Superior 6000S and Sprout Humidifier. Command is `{childLockSwitch: 0|1}` via a `setChildLock` method, read back via the same field.

Exposed via HomeKit's `LockPhysicalControls` characteristic on the existing Humidifier tile - no new accessory/service needed, and it's a purpose-built fit (Home app already renders this as a lock control).

Gated behind a new `hasChildLock` deviceType flag so other models don't get a non-functional toggle. Child lock state is intentionally not reset on power-off, unlike display/sleep/AutoPro, since it's a safety setting independent of power state.

Also cleaned up references to the third-party project used to cross-check protocol details in recent work - comments now just state the confirmed facts directly rather than citing the source.

## Test plan
- [x] `yarn build` / `yarn lint` / `yarn test` — all clean, added 4 new tests (reject-if-unsupported, payload shape, cross-device support, read-path)
- [ ] Manual verification against real Superior 6000S / Sprout hardware