### PR TITLE
Backfill CHANGELOG history from 1.16.0 through 1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Sprout Humidifier (`LEH-B381S-*`) device support: power, mode (AutoPro/Sleep/Manual), mist level, target humidity, and display.
 - Child lock support for Superior 6000S and Sprout Humidifier, exposed via the Humidifier tile's Lock Physical Controls setting in the Home app.
 
-## [1.22.0-beta.1] - 2026-Jul-12
+## [1.22.0] - 2026-Jul-12
 
 ### Fixed
 
@@ -30,6 +30,58 @@
 
 - Upgraded `axios` from `0.24.0` to `1.18.1`.
 - Enabled `noImplicitAny` and bumped the TypeScript build target to ES2022 (matching the `node >=20.19.0` engine requirement).
+
+## [1.21.0] - 2026-Jul-11
+
+### Added
+
+- NeoClassic 450S (`LUH-N451S-*`) device support: auto mode, 9 mist levels, night light, sleep mode, 30-80% target humidity.
+
+## [1.20.0] - 2026-May-05
+
+Consolidates an extended development cycle (published betas from 1.18.0 through 1.20.0-beta.21 aren't individually
+reconstructable from git history).
+
+### Fixed
+
+- Token expiration errors ("the user is not logged in") that made devices unresponsive or caused them to be silently
+  removed from HomeKit - tokens are now proactively validated and refreshed before every API call, with automatic
+  retry on 401 responses.
+- Mist and warm mist sliders showing invalid `validValues` warnings in HomeKit.
+
+### Added
+
+- Auth sessions are cached to disk and restored on restart, reducing unnecessary logins.
+- Graceful handling when VeSync's daily API quota is exceeded, instead of failing outright.
+
+### Changed
+
+- All characteristic changes now push to HomeKit immediately instead of waiting for the next poll.
+- Turning off the humidifier now resets sleep mode, warm mist, display, night light, and mist level, matching
+  physical device behavior.
+- Rapid HomeKit slider changes are now debounced (300ms) instead of flooding the VeSync API with requests.
+- Sub-services now display proper names ("Humidifier", "Mist", "Sleep Mode", etc.) instead of generic "Fan"/"Switch",
+  and user-customized names persist across restarts.
+- Substantial internal refactor: split `VeSyncAccessory`'s constructor into focused per-service setup methods, split
+  `LV600S` device matching into old/new-format prefixes, extracted shared auth and device-matching helpers.
+
+## [1.17.2] - 2026-Jan-10
+
+### Fixed
+
+- #96: LV600S mode-switching logic now matches by device prefix instead of a hardcoded model string.
+
+## [1.17.1] - 2026-Jan-06
+
+### Added
+
+- Homebridge v2.0 support.
+
+## [1.16.0] - 2025-Dec-29
+
+### Fixed
+
+- #89: User login failures ("the user is not logged in") affecting some accounts.
 
 ## [1.15.0] - 2025-Sept-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### Added
 
-- NeoClassic 450S (`LUH-N451S-*`) device support: auto mode, 9 mist levels, night light, sleep mode, 30-80% target humidity.
+- #109: NeoClassic 450S (`LUH-N451S-*`) device support: auto mode, 9 mist levels, night light, sleep mode, 30-80% target humidity.
 
 ## [1.20.0] - 2026-May-05
 
@@ -44,10 +44,10 @@ reconstructable from git history).
 
 ### Fixed
 
-- Token expiration errors ("the user is not logged in") that made devices unresponsive or caused them to be silently
-  removed from HomeKit - tokens are now proactively validated and refreshed before every API call, with automatic
-  retry on 401 responses.
-- Mist and warm mist sliders showing invalid `validValues` warnings in HomeKit.
+- #100: Token expiration errors ("the user is not logged in") that made devices unresponsive or caused them to be
+  silently removed from HomeKit - tokens are now proactively validated and refreshed before every API call, with
+  automatic retry on 401 responses.
+- #75: Mist and warm mist sliders showing invalid `validValues` warnings in HomeKit.
 
 ### Added
 
@@ -75,16 +75,37 @@ reconstructable from git history).
 
 ### Added
 
-- Homebridge v2.0 support.
+- #78: Homebridge 2.0 support.
+
+### Changed
+
+- Node 18 is no longer supported (dropped by Homebridge itself as of April 2025) - Node 20 or 22 is required.
 
 ## [1.16.0] - 2025-Dec-29
 
 ### Fixed
 
-- #89: User login failures ("the user is not logged in") affecting some accounts.
+- #89: Login failures for newer VeSync accounts and non-US accounts, caused by upstream VeSync API changes. Country
+  Code no longer needs to be configured manually - the correct region is now detected from the API response and the
+  login automatically retried with it.
 
-## [1.15.0] - 2025-Sept-08
+### Added
+
+- Debug mode exposed as a UI config option.
+- Auth tokens are now cached across restarts instead of logging in again on every reboot.
+
+### Changed
+
+- Device model matching refactored to use hardware ID prefixes instead of hardcoded full model names, broadening
+  support to regional variants without needing to add each one individually.
+
+## [1.15.0] - 2025-Sept-23
 
 ### Fixed
 
-- #89: Update login implementation for non-US users to use region
+- #89: Users outside the US were unable to log in.
+
+### Added
+
+- #86: `LEH-S601S-WUSR` device support.
+- #87: `LUH-M101S-WEUR` device support.


### PR DESCRIPTION
## Summary
CHANGELOG.md jumped straight from 1.15.0 to 1.22.0-beta.1, skipping ~15 merged PRs and several real releases in between. Backfilled using merge commits and PR descriptions:

- 1.16.0 - #93 (user login fix)
- 1.17.1 - #92 (Homebridge v2.0 support)
- 1.17.2 - #97 (LV600S mode-switching fix)
- 1.20.0 - #98 (auth reliability, HomeKit UX, code cleanup) - this one consolidates an extended beta cycle (1.18.0 through 1.20.0-beta.21) since that range only exists in git history as a single squashed commit, not individually reconstructable
- 1.21.0 - #110 (NeoClassic 450S support)

Also renamed the "1.22.0-beta.1" heading to "1.22.0" to match what was actually tagged/released.

## Test plan
Documentation only, no code changes.