### PR TITLE
Make child lock configurable via accessories.child_lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Via config.json:
         "warm_mist": false,
         "night_light": false,
         "auto_pro": false,
-        "humidity_sensor": true
+        "humidity_sensor": true,
+        "child_lock": false
       },
       "options": {
         "enableDebugMode": false,

--- a/config.schema.json
+++ b/config.schema.json
@@ -67,6 +67,12 @@
             "type": "boolean",
             "default": true,
             "description": "Enables switch to turn on / off Auto Pro Mode on LEH_S601S / LUH_O601S models"
+          },
+          "child_lock": {
+            "title": "Child Lock",
+            "type": "boolean",
+            "default": true,
+            "description": "Enables control of the physical child lock on Superior 6000S and Sprout Humidifier models"
           }
         }
       },

--- a/src/VeSyncAccessory.ts
+++ b/src/VeSyncAccessory.ts
@@ -49,6 +49,7 @@ export default class VeSyncAccessory {
   private readonly mistService: Service | undefined;
   private readonly warmMistService: Service | undefined;
   private readonly autoProService: Service | undefined;
+  private readonly hasChildLock: boolean;
 
   /**
    * Background polling interval to keep device state fresh.
@@ -79,6 +80,9 @@ export default class VeSyncAccessory {
       (Number.isFinite(configuredPollingSeconds) && configuredPollingSeconds > 0
         ? Math.max(configuredPollingSeconds, 10)
         : 30) * 1000;
+
+    this.hasChildLock =
+      !!this.device.deviceType.hasChildLock && accessories.child_lock !== false;
 
     this.setupAccessoryInfo();
     this.humidifierService = this.setupHumidifierService();
@@ -148,11 +152,19 @@ export default class VeSyncAccessory {
       .getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
       .onGet(Humidity.get.bind(this));
 
-    if (this.device.deviceType.hasChildLock) {
+    if (this.hasChildLock) {
       service
         .getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
         .onGet(ChildLock.get.bind(this))
         .onSet(ChildLock.set.bind(this));
+    } else if (
+      service.testCharacteristic(this.platform.Characteristic.LockPhysicalControls)
+    ) {
+      // Remove a previously-added characteristic if child_lock was turned off
+      // in config (or the cached accessory predates a device-support change).
+      service.removeCharacteristic(
+        service.getCharacteristic(this.platform.Characteristic.LockPhysicalControls),
+      );
     }
 
     return service;
@@ -472,7 +484,7 @@ export default class VeSyncAccessory {
       .getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
       .updateValue(device.humidityLevel);
 
-    if (device.deviceType.hasChildLock) {
+    if (this.hasChildLock) {
       this.humidifierService
         .getCharacteristic(this.platform.Characteristic.LockPhysicalControls)
         .updateValue(


### PR DESCRIPTION
## Summary
Child lock (added in #115) was gated purely by device capability (`hasChildLock`), with no way to hide it via config - inconsistent with every other optional feature (`mist`, `warm_mist`, `sleep_mode`, `display`, `night_light`, `auto_pro`, `humidity_sensor`), which all have a corresponding `accessories.*` toggle.

Added `accessories.child_lock` (default `true`) following the same pattern. Since `LockPhysicalControls` lives on the always-present Humidifier service rather than its own optional service (unlike the Fan/Switch-based features), disabling it needs to explicitly call `removeCharacteristic()` rather than just skip adding it, so a previously-cached accessory doesn't keep a stale, non-functional toggle around after the config changes.

## Test plan
- [x] `yarn build` / `yarn lint` / `yarn test` — all clean